### PR TITLE
Reformat with mpi_cpp_format.

### DIFF
--- a/include/pam_models/hill/brents.hpp
+++ b/include/pam_models/hill/brents.hpp
@@ -6,15 +6,15 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    double brents(std::function<double (double)> f,
-		  double lower,
-		  double upper,
-		  double tol=0.00000001,
-		  unsigned int max_iter=1000);
+double brents(std::function<double(double)> f,
+              double lower,
+              double upper,
+              double tol = 0.00000001,
+              unsigned int max_iter = 1000);
 
-  }
-  
 }
+
+}  // namespace pam_models

--- a/include/pam_models/hill/contractile_element.hpp
+++ b/include/pam_models/hill/contractile_element.hpp
@@ -5,83 +5,81 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    // forward declaration for
-    // using friend keyword
-    class ParallelElasticElement;
-    class SerialDampingElement;
-    class Muscle;
-    class ContractileElement;
-    class SerialElasticElement;
-    double init_muscle_force_equilibrium(double,
-					 const ParallelElasticElement&,
-					 const ContractileElement&,
-					 const SerialElasticElement&,
-					 double,
-					 double);
-    
-    
-    class ContractileElement
-    {
-    public:
-      ContractileElement(double f_max,
-			 double MP_CE_l_CEopt,
-			 double MP_CE_DeltaW_limb_des,
-			 double MP_CE_DeltaW_limb_asc,
-			 double MP_CE_v_CElimb_des,
-			 double MP_CE_v_CElimb_asc,
-			 double MP_CE_A_rel0,
-			 double MP_CE_B_rel0,
-			 double MP_CE_S_eccentric,
-			 double MP_CE_F_eccentric);
-      
-      double get_isometric_force(double l_CE);
-      double get_a_relative(double l_CE,
-			    double F_isom,
-			    double a);
-      double get_b_relative(double a);
-      
-    private:
-      
-      friend double init_muscle_force_equilibrium(double,
-						  const ParallelElasticElement&,
-						  const ContractileElement&,
-						  const SerialElasticElement&,
-						  double,
-						  double);
-      friend class ParallelElasticElement;
-      friend class SerialDampingElement;
-      friend class Muscle;
-      
-      /*! F_max in [N] for Extensor (Kistemaker et al., 2006) */
-      double MP_CE_F_max_;
-      /*! optimal length of CE in [m] for Extensor (Kistemaker et al., 2006) */
-      double MP_CE_l_CEopt_;
-      /*! width of normalized bell curve in descending branch (Moerl et al., 2012) */
-      double MP_CE_DeltaW_limb_des_;
-      /*! width of normalized bell curve in ascending branch (Moerl et al., 2012) */
-      double MP_CE_DeltaW_limb_asc_;
-      /*! exponent for descending branch (Moerl et al., 2012) */
-      double MP_CE_v_CElimb_des_;
-      /*! exponent for ascending branch (Moerl et al., 2012) */
-      double MP_CE_v_CElimb_asc_;
-      /*! parameter for contraction dynamics: maximum value of A_rel (Guenther, 1997, S. 82) */
-      double MP_CE_A_rel0_;
-      /*! parameter for contraction dynmacis: maximum value of B_rel (Guenther, 1997, S. 82)*/
-      double MP_CE_B_rel0_;
-      /*! eccentric force-velocity relation: 
-       * relation between F(v) slopes at v_CE=0 (van Soest & Bobbert, 1993)*/
-      double MP_CE_S_eccentric_;
-      /*! eccentric force-velocity relation: 
-       *  factor by which the force can exceed F_isom for large eccentric velocities
-       * (van Soest & Bobbert, 1993) */
-      double MP_CE_F_eccentric_;
+// forward declaration for
+// using friend keyword
+class ParallelElasticElement;
+class SerialDampingElement;
+class Muscle;
+class ContractileElement;
+class SerialElasticElement;
+double init_muscle_force_equilibrium(double,
+                                     const ParallelElasticElement&,
+                                     const ContractileElement&,
+                                     const SerialElasticElement&,
+                                     double,
+                                     double);
 
-    };
-    
+class ContractileElement
+{
+public:
+    ContractileElement(double f_max,
+                       double MP_CE_l_CEopt,
+                       double MP_CE_DeltaW_limb_des,
+                       double MP_CE_DeltaW_limb_asc,
+                       double MP_CE_v_CElimb_des,
+                       double MP_CE_v_CElimb_asc,
+                       double MP_CE_A_rel0,
+                       double MP_CE_B_rel0,
+                       double MP_CE_S_eccentric,
+                       double MP_CE_F_eccentric);
 
-  }
+    double get_isometric_force(double l_CE);
+    double get_a_relative(double l_CE, double F_isom, double a);
+    double get_b_relative(double a);
 
-}
+private:
+    friend double init_muscle_force_equilibrium(double,
+                                                const ParallelElasticElement&,
+                                                const ContractileElement&,
+                                                const SerialElasticElement&,
+                                                double,
+                                                double);
+    friend class ParallelElasticElement;
+    friend class SerialDampingElement;
+    friend class Muscle;
+
+    /*! F_max in [N] for Extensor (Kistemaker et al., 2006) */
+    double MP_CE_F_max_;
+    /*! optimal length of CE in [m] for Extensor (Kistemaker et al., 2006) */
+    double MP_CE_l_CEopt_;
+    /*! width of normalized bell curve in descending branch (Moerl et al., 2012)
+     */
+    double MP_CE_DeltaW_limb_des_;
+    /*! width of normalized bell curve in ascending branch (Moerl et al., 2012)
+     */
+    double MP_CE_DeltaW_limb_asc_;
+    /*! exponent for descending branch (Moerl et al., 2012) */
+    double MP_CE_v_CElimb_des_;
+    /*! exponent for ascending branch (Moerl et al., 2012) */
+    double MP_CE_v_CElimb_asc_;
+    /*! parameter for contraction dynamics: maximum value of A_rel (Guenther,
+     * 1997, S. 82) */
+    double MP_CE_A_rel0_;
+    /*! parameter for contraction dynmacis: maximum value of B_rel (Guenther,
+     * 1997, S. 82)*/
+    double MP_CE_B_rel0_;
+    /*! eccentric force-velocity relation:
+     * relation between F(v) slopes at v_CE=0 (van Soest & Bobbert, 1993)*/
+    double MP_CE_S_eccentric_;
+    /*! eccentric force-velocity relation:
+     *  factor by which the force can exceed F_isom for large eccentric
+     * velocities (van Soest & Bobbert, 1993) */
+    double MP_CE_F_eccentric_;
+};
+
+}  // namespace hill
+
+}  // namespace pam_models

--- a/include/pam_models/hill/deprecated/deprecated_muscle.hpp
+++ b/include/pam_models/hill/deprecated/deprecated_muscle.hpp
@@ -1,4 +1,4 @@
-/** 
+/**
 This class calculates the force of a muscle tendon complex and
 and the derivative of the length of the contractile element,
 depending on the length of the contractile element, the mtc length,
@@ -13,14 +13,14 @@ The code follows the MATLAB implementation by Haeufle et al.
 Copyright notice from the MATLAB model by Haeufle et al.:
 
 % Copyright (c) 2014 belongs to D. Haeufle, M. Guenther, A. Bayer, and S.
-% Schmitt 
-% All rights reserved. 
+% Schmitt
+% All rights reserved.
 % Redistribution and use in source and binary forms, with or without
 % modification, are permitted provided that the following conditions are
 % met:
 %
 %  1 Redistributions of source code must retain the above copyright notice,
-%    this list of conditions and the following disclaimer. 
+%    this list of conditions and the following disclaimer.
 %  2 Redistributions in binary form must reproduce the above copyright
 %    notice, this list of conditions and the following disclaimer in the
 %    documentation and/or other materials provided with the distribution.
@@ -45,11 +45,11 @@ Copyright notice from the MATLAB model by Haeufle et al.:
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    namespace deprecated
-    {
+namespace deprecated
+{
 
 #ifndef HILLMUSCLE_H_
 #define HILLMUSCLE_H_
@@ -57,77 +57,114 @@ namespace pam_models
 #include <functional>
 #include <vector>
 
-class HillMuscle {
-    public:
-        HillMuscle(std::string parameterfile, double a_init, double MP_l_MTC_init);
-        double get_mucle_tendon_force(double l_MTC, double dot_l_MTC, double a, double l_CE);
-        double get_dot_l_CE(double l_MTC, double dot_l_MTC, double a, double l_CE);
-    private:
-        void init_muscle(double f_max, std::vector<double>* hill_params);
-        void recalculate_muscle_tendon_force_and_dot_l_CE(double l_MTC, double dot_l_MTC, double a, double l_CE);
-        static double brents_fun(std::function<double (double)> f, double lower, double upper, double tol, unsigned int max_iter); //find zero point of function
-        double F_sum_init_muscle_force_equilib(double l_CE);
-        double find_l_CE_init(); //find lCE init according to equilibrium of forces
+class HillMuscle
+{
+public:
+    HillMuscle(std::string parameterfile, double a_init, double MP_l_MTC_init);
+    double get_mucle_tendon_force(double l_MTC,
+                                  double dot_l_MTC,
+                                  double a,
+                                  double l_CE);
+    double get_dot_l_CE(double l_MTC, double dot_l_MTC, double a, double l_CE);
 
-        double MP_l_MTC_init;   //initial length of MTC unit, current length = intial length + length from mujoco
-        double MP_l_CE_init;    //initial length of CE, current length = intial length + length from mujoco
-        double a_init;          //initial control signal for muscle tendon unit
+private:
+    void init_muscle(double f_max, std::vector<double>* hill_params);
+    void recalculate_muscle_tendon_force_and_dot_l_CE(double l_MTC,
+                                                      double dot_l_MTC,
+                                                      double a,
+                                                      double l_CE);
+    static double brents_fun(
+        std::function<double(double)> f,
+        double lower,
+        double upper,
+        double tol,
+        unsigned int max_iter);  // find zero point of function
+    double F_sum_init_muscle_force_equilib(double l_CE);
+    double find_l_CE_init();  // find lCE init according to equilibrium of
+                              // forces
 
-        bool F_MTU_current_and_dot_l_CE_current_exist = false;
-        double F_MTU_current;
-        double dot_l_CE_current;
+    double MP_l_MTC_init;  // initial length of MTC unit, current length =
+                           // intial length + length from mujoco
+    double MP_l_CE_init;  // initial length of CE, current length = intial
+                          // length + length from mujoco
+    double a_init;  // initial control signal for muscle tendon unit
 
-        double l_MTC_last_recalc;
-        double dot_l_MTC_last_recalc;
-        double a_last_recalc; 
-        double l_CE_last_recalc;
+    bool F_MTU_current_and_dot_l_CE_current_exist = false;
+    double F_MTU_current;
+    double dot_l_CE_current;
 
-        //parameters from Haeufle et al.
+    double l_MTC_last_recalc;
+    double dot_l_MTC_last_recalc;
+    double a_last_recalc;
+    double l_CE_last_recalc;
 
-        // contractile element (CE)
-        //===========================
-        double MP_CE_F_max;                 // F_max in [N] for Extensor (Kistemaker et al., 2006)
-        double MP_CE_l_CEopt;               // optimal length of CE in [m] for Extensor (Kistemaker et al., 2006)
-        double MP_CE_DeltaW_limb_des;       // width of normalized bell curve in descending branch (Moerl et al., 2012)
-        double MP_CE_DeltaW_limb_asc;       // width of normalized bell curve in ascending branch (Moerl et al., 2012)
-        double MP_CE_v_CElimb_des;           // exponent for descending branch (Moerl et al., 2012)
-        double MP_CE_v_CElimb_asc;           // exponent for ascending branch (Moerl et al., 2012)
-        double MP_CE_A_rel0;                // parameter for contraction dynamics: maximum value of A_rel (Guenther, 1997, S. 82)
-        double MP_CE_B_rel0;                // parameter for contraction dynmacis: maximum value of B_rel (Guenther, 1997, S. 82)
-        // eccentric force-velocity relation:
-        double MP_CE_S_eccentric;             // relation between F(v) slopes at v_CE=0 (van Soest & Bobbert, 1993)
-        double MP_CE_F_eccentric;           // factor by which the force can exceed F_isom for large eccentric velocities (van Soest & Bobbert, 1993)
-        
-        // paralel elastic element (PEE)
-        //===============================
+    // parameters from Haeufle et al.
 
-        double MP_PEE_L_PEE0;                               // rest length of PEE normalized to optimal lenght of CE (Guenther et al., 2007)
-        double MP_PEE_l_PEE0;       // rest length of PEE (Guenther et al., 2007)
-        double MP_PEE_v_PEE;                               // exponent of F_PEE (Moerl et al., 2012)
-        double MP_PEE_F_PEE;                               // force of PEE if l_CE is stretched to deltaWlimb_des (Moerl et al., 2012)
-        double MP_PEE_K_PEE;
-                                                            // factor of non-linearity in F_PEE (Guenther et al., 2007)
+    // contractile element (CE)
+    //===========================
+    double MP_CE_F_max;  // F_max in [N] for Extensor (Kistemaker et al., 2006)
+    double MP_CE_l_CEopt;          // optimal length of CE in [m] for Extensor
+                                   // (Kistemaker et al., 2006)
+    double MP_CE_DeltaW_limb_des;  // width of normalized bell curve in
+                                   // descending branch (Moerl et al., 2012)
+    double MP_CE_DeltaW_limb_asc;  // width of normalized bell curve in
+                                   // ascending branch (Moerl et al., 2012)
+    double MP_CE_v_CElimb_des;  // exponent for descending branch (Moerl et al.,
+                                // 2012)
+    double MP_CE_v_CElimb_asc;  // exponent for ascending branch (Moerl et al.,
+                                // 2012)
+    double MP_CE_A_rel0;  // parameter for contraction dynamics: maximum value
+                          // of A_rel (Guenther, 1997, S. 82)
+    double MP_CE_B_rel0;  // parameter for contraction dynmacis: maximum value
+                          // of B_rel (Guenther, 1997, S. 82)
+    // eccentric force-velocity relation:
+    double MP_CE_S_eccentric;  // relation between F(v) slopes at v_CE=0 (van
+                               // Soest & Bobbert, 1993)
+    double MP_CE_F_eccentric;  // factor by which the force can exceed F_isom
+                               // for large eccentric velocities (van Soest &
+                               // Bobbert, 1993)
 
-        // serial damping element (SDE)
-        //=============================
-        double MP_SDE_D_SE;               // xxx dimensionless factor to scale d_SEmax (Moerl et al., 2012)
-        double MP_SDE_R_SE;              // minimum value of d_SE normalised to d_SEmax (Moerl et al., 2012)
-        double MP_SDE_d_SEmax;
-                                            // maximum value in d_SE in [Ns/m] (Moerl et al., 2012)
+    // paralel elastic element (PEE)
+    //===============================
 
-        // serial elastic element (SEE)
-        // ============================
-        double MP_SEE_l_SEE0;       // rest length of SEE in [m] (Kistemaker et al., 2006)
-        double MP_SEE_DeltaU_SEEnll;      // relativ stretch at non-linear linear transition (Moerl et al., 2012)
-        double MP_SEE_DeltaU_SEEl;       // relativ additional stretch in the linear part providing a force increase of deltaF_SEE0 (Moerl, 2012)
-        double MP_SEE_DeltaF_SEE0;         // both force at the transition and force increase in the linear part in [N] (~ 40// of the maximal isometric muscle force)
+    double MP_PEE_L_PEE0;  // rest length of PEE normalized to optimal lenght of
+                           // CE (Guenther et al., 2007)
+    double MP_PEE_l_PEE0;  // rest length of PEE (Guenther et al., 2007)
+    double MP_PEE_v_PEE;   // exponent of F_PEE (Moerl et al., 2012)
+    double MP_PEE_F_PEE;  // force of PEE if l_CE is stretched to deltaWlimb_des
+                          // (Moerl et al., 2012)
+    double MP_PEE_K_PEE;
+    // factor of non-linearity in F_PEE (Guenther et al., 2007)
 
-        double MP_SEE_l_SEEnll;
-        double MP_SEE_v_SEE;
-        double MP_SEE_KSEEnl;
-        double MP_SEE_KSEEl;
+    // serial damping element (SDE)
+    //=============================
+    double MP_SDE_D_SE;  // xxx dimensionless factor to scale d_SEmax (Moerl et
+                         // al., 2012)
+    double MP_SDE_R_SE;  // minimum value of d_SE normalised to d_SEmax (Moerl
+                         // et al., 2012)
+    double MP_SDE_d_SEmax;
+    // maximum value in d_SE in [Ns/m] (Moerl et al., 2012)
+
+    // serial elastic element (SEE)
+    // ============================
+    double
+        MP_SEE_l_SEE0;  // rest length of SEE in [m] (Kistemaker et al., 2006)
+    double MP_SEE_DeltaU_SEEnll;  // relativ stretch at non-linear linear
+                                  // transition (Moerl et al., 2012)
+    double MP_SEE_DeltaU_SEEl;  // relativ additional stretch in the linear part
+                                // providing a force increase of deltaF_SEE0
+                                // (Moerl, 2012)
+    double MP_SEE_DeltaF_SEE0;  // both force at the transition and force
+                                // increase in the linear part in [N] (~ 40// of
+                                // the maximal isometric muscle force)
+
+    double MP_SEE_l_SEEnll;
+    double MP_SEE_v_SEE;
+    double MP_SEE_KSEEnl;
+    double MP_SEE_KSEEl;
 };
+}
+}
+}
 
-    }}}
-      
 #endif

--- a/include/pam_models/hill/factory.hpp
+++ b/include/pam_models/hill/factory.hpp
@@ -8,15 +8,13 @@
 namespace pam_models
 {
 
+namespace hill
+{
 
-  namespace hill
-  {
+Muscle from_json(std::string file_path,
+                 double a_init,
+                 double l_MTC_change_init);
+Muscle from_default_json(double a_init, double l_MTC_change_init);
+}  // namespace hill
 
-    Muscle from_json(std::string file_path,
-		   double a_init,
-		   double l_MTC_change_init);
-    Muscle from_default_json(double a_init,
-			     double l_MTC_change_init);
-  }
-
-}
+}  // namespace pam_models

--- a/include/pam_models/hill/muscle.hpp
+++ b/include/pam_models/hill/muscle.hpp
@@ -1,64 +1,55 @@
 #pragma once
 
+#include "pam_models/hill/brents.hpp"
 #include "pam_models/hill/contractile_element.hpp"
 #include "pam_models/hill/parallel_elastic_element.hpp"
 #include "pam_models/hill/serial_damping_element.hpp"
 #include "pam_models/hill/serial_elastic_element.hpp"
-#include "pam_models/hill/brents.hpp"
 
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
+double init_muscle_force_equilibrium(double l_CE,
+                                     const ParallelElasticElement& PEE,
+                                     const ContractileElement& CE,
+                                     const SerialElasticElement& SEC,
+                                     double a_init,
+                                     double MP_l_MTC_init);
 
-    double init_muscle_force_equilibrium(double l_CE,
-					 const ParallelElasticElement& PEE,
-					 const ContractileElement& CE,
-					 const SerialElasticElement& SEC,
-					 double a_init,
-					 double MP_l_MTC_init);
+class Muscle
+{
+public:
+    Muscle(ContractileElement contractile,
+           ParallelElasticElement parallel_elastic,
+           SerialDampingElement serial_damping,
+           SerialElasticElement serial_elastic,
+           double a_init,
+           double l_MTC_change_init,
+           double length);
+    std::tuple<double, double> get(double l_MTC,
+                                   double dot_l_MTC,
+                                   double a,
+                                   double l_CE);
 
+private:
+    ContractileElement contractile_;
+    ParallelElasticElement parallel_elastic_;
+    SerialDampingElement serial_damping_;
+    SerialElasticElement serial_elastic_;
 
-    
-    class Muscle
-    {
+    /*! initial length of MTC unit, current length = intial length + length from
+     * mujoco */
+    double MP_l_MTC_init_;
+    /*! initial length of CE, current length = intial length + length from
+     * mujoco */
+    double MP_l_CE_init_;
+    /*! initial control signal for muscle tendon unit */
+    double a_init_;
+};
 
-    public:
+}  // namespace hill
 
-      Muscle(ContractileElement contractile,
-	     ParallelElasticElement parallel_elastic,
-	     SerialDampingElement serial_damping,
-	     SerialElasticElement serial_elastic,
-	     double a_init,
-	     double l_MTC_change_init,
-	     double length);
-      std::tuple<double,double> get(double l_MTC,
-				    double dot_l_MTC,
-				    double a,
-				    double l_CE);
-
-    private:
-
-
-      ContractileElement contractile_;
-      ParallelElasticElement parallel_elastic_;
-      SerialDampingElement serial_damping_;
-      SerialElasticElement serial_elastic_;
-      
-      /*! initial length of MTC unit, current length = intial length + length from mujoco */
-      double MP_l_MTC_init_;
-      /*! initial length of CE, current length = intial length + length from mujoco */
-      double MP_l_CE_init_;
-      /*! initial control signal for muscle tendon unit */
-      double a_init_;
-
-    };
-
-  }
-  
-}
-
-
-
+}  // namespace pam_models

--- a/include/pam_models/hill/parallel_elastic_element.hpp
+++ b/include/pam_models/hill/parallel_elastic_element.hpp
@@ -6,43 +6,41 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    class ParallelElasticElement
-    {
+class ParallelElasticElement
+{
+public:
+    ParallelElasticElement(const ContractileElement& contractile_element,
+                           double MP_PEE_L_PEE0,
+                           double MP_PEE_v_PEE,
+                           double MP_PEE_F_PEE);
+    double get_force(double l_CE);
 
-    public:
+private:
+    friend double init_muscle_force_equilibrium(double,
+                                                const ParallelElasticElement&,
+                                                const ContractileElement&,
+                                                const SerialElasticElement&,
+                                                double,
+                                                double);
+    friend class Muscle;
 
-      ParallelElasticElement(const ContractileElement& contractile_element,
-			     double MP_PEE_L_PEE0,
-			     double MP_PEE_v_PEE,
-			     double MP_PEE_F_PEE );
-      double get_force(double l_CE);
-      
-    private:
+    /*! rest length of PEE normalized to optimal lenght of CE (Guenther et al.,
+     * 2007) */
+    double MP_PEE_L_PEE0_;
+    /*! exponent of F_PEE (Moerl et al., 2012) */
+    double MP_PEE_v_PEE_;
+    /*! force of PEE if l_CE is stretched to deltaWlimb_des (Moerl et al., 2012)
+     */
+    double MP_PEE_F_PEE_;
+    /*! rest length of PEE (Guenther et al., 2007) */
+    double MP_PEE_l_PEE0_;
+    /*! factor of non-linearity in F_PEE (Guenther et al., 2007) */
+    double MP_PEE_K_PEE_;
+};
 
-      friend double init_muscle_force_equilibrium(double,
-						  const ParallelElasticElement&,
-						  const ContractileElement&,
-						  const SerialElasticElement&,
-						  double,
-						  double);
-      friend class Muscle;
+}  // namespace hill
 
-      /*! rest length of PEE normalized to optimal lenght of CE (Guenther et al., 2007) */
-      double MP_PEE_L_PEE0_;
-      /*! exponent of F_PEE (Moerl et al., 2012) */
-      double MP_PEE_v_PEE_;
-      /*! force of PEE if l_CE is stretched to deltaWlimb_des (Moerl et al., 2012) */
-      double MP_PEE_F_PEE_;
-      /*! rest length of PEE (Guenther et al., 2007) */
-      double MP_PEE_l_PEE0_;
-      /*! factor of non-linearity in F_PEE (Guenther et al., 2007) */
-      double MP_PEE_K_PEE_;
-      
-    };
-
-  }
-
-}
+}  // namespace pam_models

--- a/include/pam_models/hill/serial_damping_element.hpp
+++ b/include/pam_models/hill/serial_damping_element.hpp
@@ -5,42 +5,38 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    class SerialDampingElement
-    {
+class SerialDampingElement
+{
+public:
+    SerialDampingElement(const ContractileElement& contractile_element,
+                         double MP_SDE_D_SE,
+                         double MP_SDE_R_SE);
+    double get_force(double F_CE,
+                     double F_PEE,
+                     double MP_CE_F_max,
+                     double dot_l_MTC,
+                     double dot_l_CE);
 
-    public:
+private:
+    friend double init_muscle_force_equilibrium(double,
+                                                const ParallelElasticElement&,
+                                                const ContractileElement&,
+                                                const SerialElasticElement&,
+                                                double,
+                                                double);
+    friend class Muscle;
 
-      SerialDampingElement(const ContractileElement& contractile_element,
-			   double MP_SDE_D_SE,
-			   double MP_SDE_R_SE);
-      double get_force(double F_CE,
-		       double F_PEE,
-		       double MP_CE_F_max,
-		       double dot_l_MTC,
-		       double dot_l_CE);
+    /*! xxx dimensionless factor to scale d_SEmax (Moerl et al., 2012) */
+    double MP_SDE_D_SE_;
+    /*! minimum value of d_SE normalised to d_SEmax (Moerl et al., 2012) */
+    double MP_SDE_R_SE_;
+    /*! maximum value in d_SE in [Ns/m] (Moerl et al., 2012) */
+    double MP_SDE_d_SEmax_;
+};
 
-    private:
-      
-      friend double init_muscle_force_equilibrium(double,
-						  const ParallelElasticElement&,
-						  const ContractileElement&,
-						  const SerialElasticElement&,
-						  double,
-						  double);
-      friend class Muscle;
-      
-      /*! xxx dimensionless factor to scale d_SEmax (Moerl et al., 2012) */
-      double MP_SDE_D_SE_;
-      /*! minimum value of d_SE normalised to d_SEmax (Moerl et al., 2012) */
-      double MP_SDE_R_SE_;
-      /*! maximum value in d_SE in [Ns/m] (Moerl et al., 2012) */ 
-      double MP_SDE_d_SEmax_;
+}  // namespace hill
 
-    };
-
-  }
-  
-}
+}  // namespace pam_models

--- a/include/pam_models/hill/serial_elastic_element.hpp
+++ b/include/pam_models/hill/serial_elastic_element.hpp
@@ -1,55 +1,53 @@
 #pragma once
 
-#include <stdlib.h>
 #include <math.h>
+#include <stdlib.h>
 #include "pam_models/hill/contractile_element.hpp"
 
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    class SerialElasticElement
-    {
-    public:
+class SerialElasticElement
+{
+public:
+    SerialElasticElement(double l_0,
+                         double deltaU_nll,
+                         double deltaU_l,
+                         double deltaF_0);
+    double init_serial_elastic_element_force(double l_mtc, double l_ce);
+    double get_force(double l_MTC, double l_CE);
 
-      SerialElasticElement(double l_0, double deltaU_nll,
-			   double deltaU_l, double deltaF_0);
-      double init_serial_elastic_element_force(double l_mtc,
-					       double l_ce);
-      double get_force(double l_MTC,double l_CE);
-	
-  private:
-
-      friend double init_muscle_force_equilibrium(double,
-						  const ParallelElasticElement&,
-						  const ContractileElement&,
-						  const SerialElasticElement&,
-						  double,
-						  double);
-      friend class Muscle;
+private:
+    friend double init_muscle_force_equilibrium(double,
+                                                const ParallelElasticElement&,
+                                                const ContractileElement&,
+                                                const SerialElasticElement&,
+                                                double,
+                                                double);
+    friend class Muscle;
 
     /** rest length of SEE in [m] (Kistemaker et al., 2006) */
     double l_0_;
     /** relative stretch at non-linear linear transition (Moerl et al., 2012) */
     double deltaU_nll_;
-    /** relative additional stretch in the linear part 
+    /** relative additional stretch in the linear part
      * providing a force increase of deltaF_0 (Moerl, 2012)
      */
     double deltaU_l_;
-    /** both force at the transition and force increase 
+    /** both force at the transition and force increase
      *  in the linear part in [N] (~ 40// of the maximal isometric muscle force)
      */
     double deltaF_0_;
-    
+
     double l_nll_;
     double v_;
     double k_nl_;
     double k_l_;
-    
-    };
-    
-  }
+};
 
-}
+}  // namespace hill
+
+}  // namespace pam_models

--- a/src/hill/brents.cpp
+++ b/src/hill/brents.cpp
@@ -3,132 +3,126 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
+// source: RosettaCode  https://rosettacode.org/wiki/Roots_of_a_function
+double brents(std::function<double(double)> f,
+              double lower,
+              double upper,
+              double tol,
+              unsigned int max_iter)
+{
+    double a = lower;
+    double b = upper;
+    double fa = f(a);  // calculated now to save function calls
+    double fb = f(b);  // calculated now to save function calls
+    double fs = 0;     // initialize
 
-    //source: RosettaCode  https://rosettacode.org/wiki/Roots_of_a_function
-    double brents(std::function<double (double)> f,
-		  double lower,
-		  double upper,
-		  double tol,
-		  unsigned int max_iter)
+    if (!(fa * fb < 0))
     {
-      double a = lower;
-      double b = upper;
-      double fa = f(a);	// calculated now to save function calls
-      double fb = f(b);	// calculated now to save function calls
-      double fs = 0;		// initialize
+        if (fb == 0) return b;
+        if (fa == 0) return a;
 
-      if (!(fa * fb < 0))
-	{
-
-	  if(fb==0)
-	    return b;
-	  if(fa==0)
-	    return a;
-
-	  throw std::runtime_error("pam_models | hills | brents_fun : root is not bracketed");
-	  
-	}
-
-      // if magnitude of f(lower_bound) is less than magnitude of f(upper_bound)
-      if (std::abs(fa) < std::abs(b))	
-	{
-	  std::swap(a,b);
-	  std::swap(fa,fb);
-	}
-
-      // c now equals the largest magnitude of the lower and upper bounds
-      double c = a;			
-      // precompute function evalutation for point c by assigning it the same value as fa
-      double fc = fa;
-      // boolean flag used to evaluate if statement later on
-      bool mflag = true;
-      // Our Root that will be returned
-      double s = 0;
-      // Only used if mflag is unset (mflag == false)
-      double d = 0;
-
-      for (unsigned int iter = 1; iter < max_iter; ++iter)
-	{
-	  // stop if converged on root or error is less than tolerance
-	  if (std::abs(b-a) < tol)
-	    {
-	      return s;
-	    } // end if
-
-	  if (fa != fc && fb != fc)
-	    {
-	      // use inverse quadratic interopolation
-	      s =	  ( a * fb * fc / ((fa - fb) * (fa - fc)) )
-		+ ( b * fa * fc / ((fb - fa) * (fb - fc)) )
-		+ ( c * fa * fb / ((fc - fa) * (fc - fb)) );
-	    }
-	  else
-	    {
-	      // secant method
-	      s = b - fb * (b - a) / (fb - fa);
-	    }
-
-	  // checks to see whether we can use the faster converging quadratic
-	  // && secant methods or if we need to use bisection
-	  if (	( (s < (3 * a + b) * 0.25) || (s > b) ) ||
-		( mflag && (std::abs(s-b) >= (std::abs(b-c) * 0.5)) ) ||
-		( !mflag && (std::abs(s-b) >= (std::abs(c-d) * 0.5)) ) ||
-		( mflag && (std::abs(b-c) < tol) ) ||
-		( !mflag && (std::abs(c-d) < tol))	)
-	    {
-	      // bisection method
-	      s = (a+b)*0.5;
-
-	      mflag = true;
-	    }
-	  else
-	    {
-	      mflag = false;
-	    }
-
-	  // calculate fs
-	  fs = f(s);
-	  // first time d is being used (wasnt used on first iteration because mflag was set)
-	  d = c;
-	  // set c equal to upper bound
-	  c = b;
-	  // set f(c) = f(b)
-	  fc = fb;	
-
-	  // fa and fs have opposite signs
-	  if ( fa * fs < 0)	
-	    {
-	      b = s;
-	      fb = fs;	// set f(b) = f(s)
-	    }
-	  else
-	    {
-	      a = s;
-	      fa = fs;	// set f(a) = f(s)
-	    }
-
-	  // if magnitude of fa is less than magnitude of fb
-	  if (std::abs(fa) < std::abs(fb)) 
-	    {
-	      // swap a and b
-	      std::swap(a,b);
-	      // make sure f(a) and f(b) are correct after swap
-	      std::swap(fa,fb);	
-	    }
-
-	} // end for
-
-      // The solution does not converge or iterations are not sufficient
-      return -1;
-
+        throw std::runtime_error(
+            "pam_models | hills | brents_fun : root is not bracketed");
     }
 
-    
-  }
+    // if magnitude of f(lower_bound) is less than magnitude of f(upper_bound)
+    if (std::abs(fa) < std::abs(b))
+    {
+        std::swap(a, b);
+        std::swap(fa, fb);
+    }
 
+    // c now equals the largest magnitude of the lower and upper bounds
+    double c = a;
+    // precompute function evalutation for point c by assigning it the same
+    // value as fa
+    double fc = fa;
+    // boolean flag used to evaluate if statement later on
+    bool mflag = true;
+    // Our Root that will be returned
+    double s = 0;
+    // Only used if mflag is unset (mflag == false)
+    double d = 0;
+
+    for (unsigned int iter = 1; iter < max_iter; ++iter)
+    {
+        // stop if converged on root or error is less than tolerance
+        if (std::abs(b - a) < tol)
+        {
+            return s;
+        }  // end if
+
+        if (fa != fc && fb != fc)
+        {
+            // use inverse quadratic interopolation
+            s = (a * fb * fc / ((fa - fb) * (fa - fc))) +
+                (b * fa * fc / ((fb - fa) * (fb - fc))) +
+                (c * fa * fb / ((fc - fa) * (fc - fb)));
+        }
+        else
+        {
+            // secant method
+            s = b - fb * (b - a) / (fb - fa);
+        }
+
+        // checks to see whether we can use the faster converging quadratic
+        // && secant methods or if we need to use bisection
+        if (((s < (3 * a + b) * 0.25) || (s > b)) ||
+            (mflag && (std::abs(s - b) >= (std::abs(b - c) * 0.5))) ||
+            (!mflag && (std::abs(s - b) >= (std::abs(c - d) * 0.5))) ||
+            (mflag && (std::abs(b - c) < tol)) ||
+            (!mflag && (std::abs(c - d) < tol)))
+        {
+            // bisection method
+            s = (a + b) * 0.5;
+
+            mflag = true;
+        }
+        else
+        {
+            mflag = false;
+        }
+
+        // calculate fs
+        fs = f(s);
+        // first time d is being used (wasnt used on first iteration because
+        // mflag was set)
+        d = c;
+        // set c equal to upper bound
+        c = b;
+        // set f(c) = f(b)
+        fc = fb;
+
+        // fa and fs have opposite signs
+        if (fa * fs < 0)
+        {
+            b = s;
+            fb = fs;  // set f(b) = f(s)
+        }
+        else
+        {
+            a = s;
+            fa = fs;  // set f(a) = f(s)
+        }
+
+        // if magnitude of fa is less than magnitude of fb
+        if (std::abs(fa) < std::abs(fb))
+        {
+            // swap a and b
+            std::swap(a, b);
+            // make sure f(a) and f(b) are correct after swap
+            std::swap(fa, fb);
+        }
+
+    }  // end for
+
+    // The solution does not converge or iterations are not sufficient
+    return -1;
 }
 
- 
+}  // namespace hill
+
+}  // namespace pam_models

--- a/src/hill/factory.cpp
+++ b/src/hill/factory.cpp
@@ -3,85 +3,80 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    Muscle from_json(std::string file_path,
-		   double a_init,
-		   double l_MTC_change_init)
+Muscle from_json(std::string file_path, double a_init, double l_MTC_change_init)
+{
+    json_helper::Jsonhelper jh;
+
+    try
     {
-
-      json_helper::Jsonhelper jh;
-
-      try
-	{
-	  jh.parse(file_path);
-	}
-      catch(...)
-	{
-	  std::stringstream ss;
-	  ss << "Failed to read JSON file " << file_path << "\n";
-	  std::string error = ss.str();
-	  throw error;
-	}
-
-      double f_max = jh.j["contractile"]["f_max"].get<double>();
-      double l_CEopt = jh.j["contractile"]["l_CEopt"].get<double>();
-      double delta_w_limb_desc = jh.j["contractile"]["delta_w_limb_desc"].get<double>();
-      double delta_w_limb_asc = jh.j["contractile"]["delta_w_limb_asc"].get<double>();
-      double limb_desc = jh.j["contractile"]["limb_desc"].get<double>();
-      double limb_asc = jh.j["contractile"]["limb_asc"].get<double>();
-      double a_rel0 = jh.j["contractile"]["a_rel0"].get<double>();
-      double b_rel0 = jh.j["contractile"]["b_rel0"].get<double>();
-      double s_eccentric = jh.j["contractile"]["s_eccentric"].get<double>();
-      double c_eccentric = jh.j["contractile"]["c_eccentric"].get<double>();
-
-      ContractileElement ce(f_max,
-			    l_CEopt,
-			    delta_w_limb_desc,
-			    delta_w_limb_asc,
-			    limb_desc,
-			    limb_asc,
-			    a_rel0,
-			    b_rel0,
-			    s_eccentric,
-			    c_eccentric);
-
-      double L = jh.j["parallel_elastic"]["L"].get<double>();
-      double v = jh.j["parallel_elastic"]["v"].get<double>();
-      double F = jh.j["parallel_elastic"]["F"].get<double>();
-
-      ParallelElasticElement pee(ce,L,v,F);
-
-      double d_se = jh.j["serial_damping"]["d_se"].get<double>();
-      double r_se = jh.j["serial_damping"]["r_se"].get<double>();
-      
-      SerialDampingElement sde(ce,d_se,r_se);
-
-      double l = jh.j["serial_elastic"]["l"].get<double>();
-      double delta_u_nll = jh.j["serial_elastic"]["delta_u_nll"].get<double>();
-      double delta_u_l = jh.j["serial_elastic"]["delta_u_l"].get<double>();
-      double delta_f = jh.j["serial_elastic"]["delta_f"].get<double>();
-
-      SerialElasticElement see(l,delta_u_nll,delta_u_l,delta_f);
-
-      double length = jh.j["length"].get<double>();
-
-      Muscle muscle(ce,pee,sde,see,a_init,l_MTC_change_init,length);
-
-      return muscle;
-      
+        jh.parse(file_path);
+    }
+    catch (...)
+    {
+        std::stringstream ss;
+        ss << "Failed to read JSON file " << file_path << "\n";
+        std::string error = ss.str();
+        throw error;
     }
 
+    double f_max = jh.j["contractile"]["f_max"].get<double>();
+    double l_CEopt = jh.j["contractile"]["l_CEopt"].get<double>();
+    double delta_w_limb_desc =
+        jh.j["contractile"]["delta_w_limb_desc"].get<double>();
+    double delta_w_limb_asc =
+        jh.j["contractile"]["delta_w_limb_asc"].get<double>();
+    double limb_desc = jh.j["contractile"]["limb_desc"].get<double>();
+    double limb_asc = jh.j["contractile"]["limb_asc"].get<double>();
+    double a_rel0 = jh.j["contractile"]["a_rel0"].get<double>();
+    double b_rel0 = jh.j["contractile"]["b_rel0"].get<double>();
+    double s_eccentric = jh.j["contractile"]["s_eccentric"].get<double>();
+    double c_eccentric = jh.j["contractile"]["c_eccentric"].get<double>();
 
-    Muscle from_default_json(double a_init,
-			     double l_MTC_change_init)
-    {
-      std::string path(JSON_DEFAULT_CONFIG_FILE);
-      return from_json(path,a_init,l_MTC_change_init);
-    }
-    
-  }
+    ContractileElement ce(f_max,
+                          l_CEopt,
+                          delta_w_limb_desc,
+                          delta_w_limb_asc,
+                          limb_desc,
+                          limb_asc,
+                          a_rel0,
+                          b_rel0,
+                          s_eccentric,
+                          c_eccentric);
 
-    
+    double L = jh.j["parallel_elastic"]["L"].get<double>();
+    double v = jh.j["parallel_elastic"]["v"].get<double>();
+    double F = jh.j["parallel_elastic"]["F"].get<double>();
+
+    ParallelElasticElement pee(ce, L, v, F);
+
+    double d_se = jh.j["serial_damping"]["d_se"].get<double>();
+    double r_se = jh.j["serial_damping"]["r_se"].get<double>();
+
+    SerialDampingElement sde(ce, d_se, r_se);
+
+    double l = jh.j["serial_elastic"]["l"].get<double>();
+    double delta_u_nll = jh.j["serial_elastic"]["delta_u_nll"].get<double>();
+    double delta_u_l = jh.j["serial_elastic"]["delta_u_l"].get<double>();
+    double delta_f = jh.j["serial_elastic"]["delta_f"].get<double>();
+
+    SerialElasticElement see(l, delta_u_nll, delta_u_l, delta_f);
+
+    double length = jh.j["length"].get<double>();
+
+    Muscle muscle(ce, pee, sde, see, a_init, l_MTC_change_init, length);
+
+    return muscle;
 }
+
+Muscle from_default_json(double a_init, double l_MTC_change_init)
+{
+    std::string path(JSON_DEFAULT_CONFIG_FILE);
+    return from_json(path, a_init, l_MTC_change_init);
+}
+
+}  // namespace hill
+
+}  // namespace pam_models

--- a/src/hill/internal/contractile_element.cpp
+++ b/src/hill/internal/contractile_element.cpp
@@ -3,57 +3,57 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    ContractileElement::ContractileElement(double f_max,
-					   double MP_CE_l_CEopt,
-					   double MP_CE_DeltaW_limb_des,
-					   double MP_CE_DeltaW_limb_asc,
-					   double MP_CE_v_CElimb_des,
-					   double MP_CE_v_CElimb_asc,
-					   double MP_CE_A_rel0,
-					   double MP_CE_B_rel0,
-					   double MP_CE_S_eccentric,
-					   double MP_CE_F_eccentric)
-      : MP_CE_F_max_(f_max),
-	MP_CE_l_CEopt_(MP_CE_l_CEopt),
-	MP_CE_DeltaW_limb_des_(MP_CE_DeltaW_limb_des),
-	MP_CE_DeltaW_limb_asc_(MP_CE_DeltaW_limb_asc),
-	MP_CE_v_CElimb_des_(MP_CE_v_CElimb_des),
-	MP_CE_v_CElimb_asc_(MP_CE_v_CElimb_asc),
-	MP_CE_A_rel0_(MP_CE_A_rel0),
-	MP_CE_B_rel0_(MP_CE_B_rel0),
-	MP_CE_S_eccentric_(MP_CE_S_eccentric),
-	MP_CE_F_eccentric_(MP_CE_F_eccentric)
-    {}
-	  
-	// line 153
-	double ContractileElement::get_isometric_force(double l_CE)
-	{
-	  if (MP_CE_l_CEopt_<=l_CE)
-	    return ( exp( - pow( fabs(  ((l_CE/MP_CE_l_CEopt_)-1)/MP_CE_DeltaW_limb_des_  ),
-				 MP_CE_v_CElimb_des_ ) ));
-	  if(MP_CE_l_CEopt_>l_CE && MP_CE_l_CEopt_>l_CE)
-	    return ( exp( - pow( fabs(  ((l_CE/MP_CE_l_CEopt_)-1)/MP_CE_DeltaW_limb_asc_  ),
-				 MP_CE_v_CElimb_asc_ ) ));
-	  return 0;
-
-	}
-
-    double ContractileElement::get_a_relative(double l_CE,
-					      double F_isom,
-					      double a)
-    {
-      return ( 1.0*(l_CE<MP_CE_l_CEopt_) +
-	       F_isom*(l_CE>=MP_CE_l_CEopt_) )*MP_CE_A_rel0_*1/4*(1+3*a);
-    }
-
-    double ContractileElement::get_b_relative(double a)
-    {
-      return MP_CE_B_rel0_*1*1/7*(3+4*a);
-    }
-
-  }
-
+ContractileElement::ContractileElement(double f_max,
+                                       double MP_CE_l_CEopt,
+                                       double MP_CE_DeltaW_limb_des,
+                                       double MP_CE_DeltaW_limb_asc,
+                                       double MP_CE_v_CElimb_des,
+                                       double MP_CE_v_CElimb_asc,
+                                       double MP_CE_A_rel0,
+                                       double MP_CE_B_rel0,
+                                       double MP_CE_S_eccentric,
+                                       double MP_CE_F_eccentric)
+    : MP_CE_F_max_(f_max),
+      MP_CE_l_CEopt_(MP_CE_l_CEopt),
+      MP_CE_DeltaW_limb_des_(MP_CE_DeltaW_limb_des),
+      MP_CE_DeltaW_limb_asc_(MP_CE_DeltaW_limb_asc),
+      MP_CE_v_CElimb_des_(MP_CE_v_CElimb_des),
+      MP_CE_v_CElimb_asc_(MP_CE_v_CElimb_asc),
+      MP_CE_A_rel0_(MP_CE_A_rel0),
+      MP_CE_B_rel0_(MP_CE_B_rel0),
+      MP_CE_S_eccentric_(MP_CE_S_eccentric),
+      MP_CE_F_eccentric_(MP_CE_F_eccentric)
+{
 }
+
+// line 153
+double ContractileElement::get_isometric_force(double l_CE)
+{
+    if (MP_CE_l_CEopt_ <= l_CE)
+        return (exp(
+            -pow(fabs(((l_CE / MP_CE_l_CEopt_) - 1) / MP_CE_DeltaW_limb_des_),
+                 MP_CE_v_CElimb_des_)));
+    if (MP_CE_l_CEopt_ > l_CE && MP_CE_l_CEopt_ > l_CE)
+        return (exp(
+            -pow(fabs(((l_CE / MP_CE_l_CEopt_) - 1) / MP_CE_DeltaW_limb_asc_),
+                 MP_CE_v_CElimb_asc_)));
+    return 0;
+}
+
+double ContractileElement::get_a_relative(double l_CE, double F_isom, double a)
+{
+    return (1.0 * (l_CE < MP_CE_l_CEopt_) + F_isom * (l_CE >= MP_CE_l_CEopt_)) *
+           MP_CE_A_rel0_ * 1 / 4 * (1 + 3 * a);
+}
+
+double ContractileElement::get_b_relative(double a)
+{
+    return MP_CE_B_rel0_ * 1 * 1 / 7 * (3 + 4 * a);
+}
+
+}  // namespace hill
+
+}  // namespace pam_models

--- a/src/hill/internal/deprecated/deprecated_muscle.cpp
+++ b/src/hill/internal/deprecated/deprecated_muscle.cpp
@@ -58,177 +58,266 @@ Copyright notice from the MATLAB model by Haeufle et al.:
 namespace pam_models
 {
 
-  namespace hill
-  {
-
-    namespace deprecated
-    {
-
-
-
-HillMuscle::HillMuscle(std::string parameterfile, double a_init, double l_MTC_change_init)
+namespace hill
 {
-	double f_max;
-	std::vector<double>  hill_params;
-	json_helper::Jsonhelper jh(parameterfile);
-	f_max = jh.j["f_max"];
-	this->MP_l_MTC_init = (double)jh.j["length"] + l_MTC_change_init;
 
-	jh.json2vector("hill_params", hill_params);
+namespace deprecated
+{
 
-	init_muscle(f_max, &hill_params);
+HillMuscle::HillMuscle(std::string parameterfile,
+                       double a_init,
+                       double l_MTC_change_init)
+{
+    double f_max;
+    std::vector<double> hill_params;
+    json_helper::Jsonhelper jh(parameterfile);
+    f_max = jh.j["f_max"];
+    this->MP_l_MTC_init = (double)jh.j["length"] + l_MTC_change_init;
+
+    jh.json2vector("hill_params", hill_params);
+
+    init_muscle(f_max, &hill_params);
 
     this->a_init = a_init;
     this->MP_l_CE_init = find_l_CE_init();
-    //printf("lce_init: %f\n", this->MP_l_CE_init);*/
+    // printf("lce_init: %f\n", this->MP_l_CE_init);*/
 }
 
 void HillMuscle::init_muscle(double f_max, std::vector<double>* hill_params)
 {
-    //parameters from Haeufle et al.
+    // parameters from Haeufle et al.
 
-	// contractile element (CE)
-	//===========================
+    // contractile element (CE)
+    //===========================
 
-	MP_CE_F_max = f_max;    // F_max in [N] for Extensor (Kistemaker et al., 2006)  --- set fixed
-	MP_CE_l_CEopt = (*hill_params)[0]; // optimal length of CE in [m] for Extensor (Kistemaker et al., 2006) --- learn two values
-	MP_CE_DeltaW_limb_des = (*hill_params)[1];       	// width of normalized bell curve in descending branch (Moerl et al., 2012) --- learn one value
-	MP_CE_DeltaW_limb_asc = (*hill_params)[2];       	// width of normalized bell curve in ascending branch (Moerl et al., 2012) --- learn one value
-	MP_CE_v_CElimb_des = (*hill_params)[3];           	// exponent for descending branch (Moerl et al., 2012) --- learn two values
-	MP_CE_v_CElimb_asc = (*hill_params)[4];           	// exponent for ascending branch (Moerl et al., 2012) --- learn two values
-	MP_CE_A_rel0 = (*hill_params)[5];                	// parameter for contraction dynamics: maximum value of A_rel (Guenther, 1997, S. 82) --- learn two values
-	MP_CE_B_rel0 = (*hill_params)[6];                	// parameter for contraction dynmacis: maximum value of B_rel (Guenther, 1997, S. 82) --- learn two values
-	// eccentric force-velocity relation:
-	MP_CE_S_eccentric  = (*hill_params)[7];             	// relation between F(v) slopes at v_CE=0 (van Soest & Bobbert, 1993) --- learn two values
-	MP_CE_F_eccentric  = (*hill_params)[8];           	// factor by which the force can exceed F_isom for large eccentric velocities (van Soest & Bobbert, 1993) --- learn two values
+    MP_CE_F_max = f_max;  // F_max in [N] for Extensor (Kistemaker et al., 2006)
+                          // --- set fixed
+    MP_CE_l_CEopt =
+        (*hill_params)[0];  // optimal length of CE in [m] for Extensor
+                            // (Kistemaker et al., 2006) --- learn two values
+    MP_CE_DeltaW_limb_des =
+        (*hill_params)[1];  // width of normalized bell curve in descending
+                            // branch (Moerl et al., 2012) --- learn one value
+    MP_CE_DeltaW_limb_asc =
+        (*hill_params)[2];  // width of normalized bell curve in ascending
+                            // branch (Moerl et al., 2012) --- learn one value
+    MP_CE_v_CElimb_des =
+        (*hill_params)[3];  // exponent for descending branch (Moerl et al.,
+                            // 2012) --- learn two values
+    MP_CE_v_CElimb_asc =
+        (*hill_params)[4];  // exponent for ascending branch (Moerl et al.,
+                            // 2012) --- learn two values
+    MP_CE_A_rel0 = (*hill_params)[5];  // parameter for contraction dynamics:
+                                       // maximum value of A_rel (Guenther,
+                                       // 1997, S. 82) --- learn two values
+    MP_CE_B_rel0 = (*hill_params)[6];  // parameter for contraction dynmacis:
+                                       // maximum value of B_rel (Guenther,
+                                       // 1997, S. 82) --- learn two values
+    // eccentric force-velocity relation:
+    MP_CE_S_eccentric =
+        (*hill_params)[7];  // relation between F(v) slopes at v_CE=0 (van Soest
+                            // & Bobbert, 1993) --- learn two values
+    MP_CE_F_eccentric =
+        (*hill_params)[8];  // factor by which the force can exceed F_isom for
+                            // large eccentric velocities (van Soest & Bobbert,
+                            // 1993) --- learn two values
 
-	// paralel elastic element (PEE)
-	//===============================
+    // paralel elastic element (PEE)
+    //===============================
 
-	MP_PEE_L_PEE0   = (*hill_params)[9];                               // rest length of PEE normalized to optimal lenght of CE (Guenther et al., 2007) --- keep
-	MP_PEE_l_PEE0   = MP_PEE_L_PEE0* MP_CE_l_CEopt;      // rest length of PEE (Guenther et al., 2007)
-	MP_PEE_v_PEE    = (*hill_params)[10];                               // exponent of F_PEE (Moerl et al., 2012) --- keep
-	MP_PEE_F_PEE    = (*hill_params)[11];              // force of PEE if l_CE is stretched to deltaWlimb_des (Moerl et al., 2012) --- learn one value
-	MP_PEE_K_PEE    = MP_PEE_F_PEE *( MP_CE_F_max / pow( MP_CE_l_CEopt*( MP_CE_DeltaW_limb_des+1-MP_PEE_L_PEE0),  MP_PEE_v_PEE ));
-														 // factor of non-linearity in F_PEE (Guenther et al., 2007)
+    MP_PEE_L_PEE0 =
+        (*hill_params)[9];  // rest length of PEE normalized to optimal lenght
+                            // of CE (Guenther et al., 2007) --- keep
+    MP_PEE_l_PEE0 =
+        MP_PEE_L_PEE0 *
+        MP_CE_l_CEopt;  // rest length of PEE (Guenther et al., 2007)
+    MP_PEE_v_PEE =
+        (*hill_params)[10];  // exponent of F_PEE (Moerl et al., 2012) --- keep
+    MP_PEE_F_PEE = (*hill_params)[11];  // force of PEE if l_CE is stretched to
+                                        // deltaWlimb_des (Moerl et al., 2012)
+                                        // --- learn one value
+    MP_PEE_K_PEE =
+        MP_PEE_F_PEE *
+        (MP_CE_F_max /
+         pow(MP_CE_l_CEopt * (MP_CE_DeltaW_limb_des + 1 - MP_PEE_L_PEE0),
+             MP_PEE_v_PEE));
+    // factor of non-linearity in F_PEE (Guenther et al., 2007)
 
-	// serial damping element (SDE)
-	//=============================
-	MP_SDE_D_SE    = (*hill_params)[12];               // xxx dimensionless factor to scale d_SEmax (Moerl et al., 2012) --- keep
-	MP_SDE_R_SE    = (*hill_params)[13];              // minimum value of d_SE normalised to d_SEmax (Moerl et al., 2012) --- keep
-	MP_SDE_d_SEmax = MP_SDE_D_SE*( MP_CE_F_max* MP_CE_A_rel0)/( MP_CE_l_CEopt* MP_CE_B_rel0);
-										// maximum value in d_SE in [Ns/m] (Moerl et al., 2012)
+    // serial damping element (SDE)
+    //=============================
+    MP_SDE_D_SE = (*hill_params)[12];  // xxx dimensionless factor to scale
+                                       // d_SEmax (Moerl et al., 2012) --- keep
+    MP_SDE_R_SE = (*hill_params)[13];  // minimum value of d_SE normalised to
+                                       // d_SEmax (Moerl et al., 2012) --- keep
+    MP_SDE_d_SEmax = MP_SDE_D_SE * (MP_CE_F_max * MP_CE_A_rel0) /
+                     (MP_CE_l_CEopt * MP_CE_B_rel0);
+    // maximum value in d_SE in [Ns/m] (Moerl et al., 2012)
 
-	// serial elastic element (SEE)
-	// ============================
-	MP_SEE_l_SEE0        = (*hill_params)[14];      // rest length of SEE in [m] (Kistemaker et al., 2006) --- learn two values
-	MP_SEE_DeltaU_SEEnll = (*hill_params)[15];      				// relativ stretch at non-linear linear transition (Moerl et al., 2012) --- keep
-	MP_SEE_DeltaU_SEEl   = (*hill_params)[16];       				// relativ additional stretch in the linear part providing a force increase of deltaF_SEE0 (Moerl, 2012) --- keep
-	MP_SEE_DeltaF_SEE0   = (*hill_params)[17];        // both force at the transition and force increase in the linear part in [N] (~ 40// of the maximal isometric muscle force) --- keep, set by iesometric force -> 480
+    // serial elastic element (SEE)
+    // ============================
+    MP_SEE_l_SEE0 =
+        (*hill_params)[14];  // rest length of SEE in [m] (Kistemaker et al.,
+                             // 2006) --- learn two values
+    MP_SEE_DeltaU_SEEnll =
+        (*hill_params)[15];  // relativ stretch at non-linear linear transition
+                             // (Moerl et al., 2012) --- keep
+    MP_SEE_DeltaU_SEEl =
+        (*hill_params)[16];  // relativ additional stretch in the linear part
+                             // providing a force increase of deltaF_SEE0
+                             // (Moerl, 2012) --- keep
+    MP_SEE_DeltaF_SEE0 =
+        (*hill_params)[17];  // both force at the transition and force increase
+                             // in the linear part in [N] (~ 40// of the maximal
+                             // isometric muscle force) --- keep, set by
+                             // iesometric force -> 480
 
-	MP_SEE_l_SEEnll      = (1 + MP_SEE_DeltaU_SEEnll)* MP_SEE_l_SEE0;
-	MP_SEE_v_SEE         = MP_SEE_DeltaU_SEEnll/ MP_SEE_DeltaU_SEEl;
-	MP_SEE_KSEEnl        = MP_SEE_DeltaF_SEE0 / pow( MP_SEE_DeltaU_SEEnll* MP_SEE_l_SEE0,  MP_SEE_v_SEE);
-	MP_SEE_KSEEl         = MP_SEE_DeltaF_SEE0 / ( MP_SEE_DeltaU_SEEl* MP_SEE_l_SEE0);
-
-
+    MP_SEE_l_SEEnll = (1 + MP_SEE_DeltaU_SEEnll) * MP_SEE_l_SEE0;
+    MP_SEE_v_SEE = MP_SEE_DeltaU_SEEnll / MP_SEE_DeltaU_SEEl;
+    MP_SEE_KSEEnl = MP_SEE_DeltaF_SEE0 /
+                    pow(MP_SEE_DeltaU_SEEnll * MP_SEE_l_SEE0, MP_SEE_v_SEE);
+    MP_SEE_KSEEl = MP_SEE_DeltaF_SEE0 / (MP_SEE_DeltaU_SEEl * MP_SEE_l_SEE0);
 }
 
-double HillMuscle::get_mucle_tendon_force(double l_MTC, double dot_l_MTC, double a, double l_CE)
+double HillMuscle::get_mucle_tendon_force(double l_MTC,
+                                          double dot_l_MTC,
+                                          double a,
+                                          double l_CE)
 {
-	if(!F_MTU_current_and_dot_l_CE_current_exist || (l_MTC!=l_MTC_last_recalc || dot_l_MTC!=dot_l_MTC_last_recalc || a!=a_last_recalc || l_CE!=l_CE_last_recalc))
-	{
-		recalculate_muscle_tendon_force_and_dot_l_CE(l_MTC, dot_l_MTC, a, l_CE);
-		F_MTU_current_and_dot_l_CE_current_exist = true;
-	}
-	return F_MTU_current;
+    if (!F_MTU_current_and_dot_l_CE_current_exist ||
+        (l_MTC != l_MTC_last_recalc || dot_l_MTC != dot_l_MTC_last_recalc ||
+         a != a_last_recalc || l_CE != l_CE_last_recalc))
+    {
+        recalculate_muscle_tendon_force_and_dot_l_CE(l_MTC, dot_l_MTC, a, l_CE);
+        F_MTU_current_and_dot_l_CE_current_exist = true;
+    }
+    return F_MTU_current;
 }
 
-double HillMuscle::get_dot_l_CE(double l_MTC, double dot_l_MTC, double a, double l_CE)
+double HillMuscle::get_dot_l_CE(double l_MTC,
+                                double dot_l_MTC,
+                                double a,
+                                double l_CE)
 {
-	if(!F_MTU_current_and_dot_l_CE_current_exist || (l_MTC!=l_MTC_last_recalc || dot_l_MTC!=dot_l_MTC_last_recalc || a!=a_last_recalc || l_CE!=l_CE_last_recalc))
-	{
-		recalculate_muscle_tendon_force_and_dot_l_CE(l_MTC, dot_l_MTC, a, l_CE);
-		F_MTU_current_and_dot_l_CE_current_exist = true;
-	}
-	return dot_l_CE_current;
+    if (!F_MTU_current_and_dot_l_CE_current_exist ||
+        (l_MTC != l_MTC_last_recalc || dot_l_MTC != dot_l_MTC_last_recalc ||
+         a != a_last_recalc || l_CE != l_CE_last_recalc))
+    {
+        recalculate_muscle_tendon_force_and_dot_l_CE(l_MTC, dot_l_MTC, a, l_CE);
+        F_MTU_current_and_dot_l_CE_current_exist = true;
+    }
+    return dot_l_CE_current;
 }
 
-void HillMuscle::recalculate_muscle_tendon_force_and_dot_l_CE(double l_MTC, double dot_l_MTC, double a, double l_CE)
+void HillMuscle::recalculate_muscle_tendon_force_and_dot_l_CE(double l_MTC,
+                                                              double dot_l_MTC,
+                                                              double a,
+                                                              double l_CE)
 {
-	l_MTC_last_recalc = l_MTC;
-	dot_l_MTC_last_recalc = dot_l_MTC;
-	a_last_recalc = a;
-	l_CE_last_recalc = l_CE;
+    l_MTC_last_recalc = l_MTC;
+    dot_l_MTC_last_recalc = dot_l_MTC;
+    a_last_recalc = a;
+    l_CE_last_recalc = l_CE;
 
-	l_MTC = l_MTC + MP_l_MTC_init;
+    l_MTC = l_MTC + MP_l_MTC_init;
     l_CE = l_CE + MP_l_CE_init;
-	double l_SE = l_MTC - l_CE;
+    double l_SE = l_MTC - l_CE;
 
-	double F_isom = 0;
-	if (MP_CE_l_CEopt<=l_CE)
-		F_isom += ( exp( - pow( abs(  ((l_CE/MP_CE_l_CEopt)-1)/MP_CE_DeltaW_limb_des  ), MP_CE_v_CElimb_des ) ));
-	if(MP_CE_l_CEopt>l_CE && MP_CE_l_CEopt>l_CE)
-		F_isom += ( exp( - pow( abs(  ((l_CE/MP_CE_l_CEopt)-1)/MP_CE_DeltaW_limb_asc  ), MP_CE_v_CElimb_asc ) ));
+    double F_isom = 0;
+    if (MP_CE_l_CEopt <= l_CE)
+        F_isom +=
+            (exp(-pow(abs(((l_CE / MP_CE_l_CEopt) - 1) / MP_CE_DeltaW_limb_des),
+                      MP_CE_v_CElimb_des)));
+    if (MP_CE_l_CEopt > l_CE && MP_CE_l_CEopt > l_CE)
+        F_isom +=
+            (exp(-pow(abs(((l_CE / MP_CE_l_CEopt) - 1) / MP_CE_DeltaW_limb_asc),
+                      MP_CE_v_CElimb_asc)));
 
-	double F_PEE = 0;
-	if(l_CE>=MP_PEE_l_PEE0)
-	{
-		F_PEE = MP_PEE_K_PEE*pow(l_CE-MP_PEE_l_PEE0, MP_PEE_v_PEE);
-	}
+    double F_PEE = 0;
+    if (l_CE >= MP_PEE_l_PEE0)
+    {
+        F_PEE = MP_PEE_K_PEE * pow(l_CE - MP_PEE_l_PEE0, MP_PEE_v_PEE);
+    }
 
-	double F_SEE = (l_SE>=MP_SEE_l_SEEnll)   *   (MP_SEE_DeltaF_SEE0+MP_SEE_KSEEl*(l_SE-MP_SEE_l_SEEnll));
-	if (l_SE>MP_SEE_l_SEE0 && l_SE<MP_SEE_l_SEEnll)
-		F_SEE+=MP_SEE_KSEEnl*(pow(l_SE-MP_SEE_l_SEE0, MP_SEE_v_SEE));
+    double F_SEE =
+        (l_SE >= MP_SEE_l_SEEnll) *
+        (MP_SEE_DeltaF_SEE0 + MP_SEE_KSEEl * (l_SE - MP_SEE_l_SEEnll));
+    if (l_SE > MP_SEE_l_SEE0 && l_SE < MP_SEE_l_SEEnll)
+        F_SEE += MP_SEE_KSEEnl * (pow(l_SE - MP_SEE_l_SEE0, MP_SEE_v_SEE));
 
-	double A_rel = ( 1.0*(l_CE<MP_CE_l_CEopt) + F_isom*(l_CE>=MP_CE_l_CEopt) )*MP_CE_A_rel0*1/4*(1+3*a);
+    double A_rel =
+        (1.0 * (l_CE < MP_CE_l_CEopt) + F_isom * (l_CE >= MP_CE_l_CEopt)) *
+        MP_CE_A_rel0 * 1 / 4 * (1 + 3 * a);
 
-	double B_rel = MP_CE_B_rel0*1*1/7*(3+4*a);
+    double B_rel = MP_CE_B_rel0 * 1 * 1 / 7 * (3 + 4 * a);
 
-	double D_0 = MP_CE_l_CEopt * B_rel * MP_SDE_d_SEmax * ( MP_SDE_R_SE + (1-MP_SDE_R_SE) * ( a * F_isom + F_PEE/MP_CE_F_max ) );
+    double D_0 =
+        MP_CE_l_CEopt * B_rel * MP_SDE_d_SEmax *
+        (MP_SDE_R_SE + (1 - MP_SDE_R_SE) * (a * F_isom + F_PEE / MP_CE_F_max));
 
-	double C_2 = MP_SDE_d_SEmax * ( MP_SDE_R_SE - ( A_rel - F_PEE/MP_CE_F_max ) * (1 - MP_SDE_R_SE) );
+    double C_2 = MP_SDE_d_SEmax * (MP_SDE_R_SE - (A_rel - F_PEE / MP_CE_F_max) *
+                                                     (1 - MP_SDE_R_SE));
 
-	double C_1 = - ( C_2*dot_l_MTC + D_0 + F_SEE - F_PEE + (MP_CE_F_max*A_rel) );
+    double C_1 =
+        -(C_2 * dot_l_MTC + D_0 + F_SEE - F_PEE + (MP_CE_F_max * A_rel));
 
-	double C_0 = D_0*dot_l_MTC + MP_CE_l_CEopt * B_rel * ( F_SEE - F_PEE - MP_CE_F_max*a*F_isom );
+    double C_0 =
+        D_0 * dot_l_MTC +
+        MP_CE_l_CEopt * B_rel * (F_SEE - F_PEE - MP_CE_F_max * a * F_isom);
 
-	double dot_l_CE = (-C_1-sqrt(C_1*C_1-4*C_2*C_0))/(2*C_2); //quadratic equation for concentric contractions (-sqrt)
+    double dot_l_CE =
+        (-C_1 - sqrt(C_1 * C_1 - 4 * C_2 * C_0)) /
+        (2 * C_2);  // quadratic equation for concentric contractions (-sqrt)
 
-	//printf("hillMuscle -dot_l_MTC:%f -B_rel:%f -a:%f -F_isom:%f -F_PEE:%f  -F_SEE:%f  -D_0:%f\n", dot_l_MTC, B_rel, a, F_isom, F_PEE, F_SEE, D_0);
-	//printf("hillMuscle -C0:%f -C1:%f -C2: %f\n", C_0, C_1, C_2);
-	//printf("hillMuscle-dot_l_CE: %f\n", dot_l_CE);
+    // printf("hillMuscle -dot_l_MTC:%f -B_rel:%f -a:%f -F_isom:%f -F_PEE:%f
+    // -F_SEE:%f  -D_0:%f\n", dot_l_MTC, B_rel, a, F_isom, F_PEE, F_SEE, D_0);
+    // printf("hillMuscle -C0:%f -C1:%f -C2: %f\n", C_0, C_1, C_2);
+    // printf("hillMuscle-dot_l_CE: %f\n", dot_l_CE);
 
-	if(dot_l_CE>0)  //dot_l_CE > 0 -> eccentric contraction -> recalculate dot_l_CE
-	{
-		double A_rel_con = A_rel;
-		double B_rel_con = B_rel;
-		A_rel = -MP_CE_F_eccentric*a*F_isom;
-		B_rel = a*F_isom*(1-MP_CE_F_eccentric)/(a*F_isom+A_rel_con)*B_rel_con/MP_CE_S_eccentric;
-		D_0 = MP_CE_l_CEopt * B_rel * MP_SDE_d_SEmax * ( MP_SDE_R_SE + (1-MP_SDE_R_SE) * ( a * F_isom + F_PEE/MP_CE_F_max ) );
-		C_2 = MP_SDE_d_SEmax * ( MP_SDE_R_SE - ( A_rel - F_PEE/MP_CE_F_max ) * (1 - MP_SDE_R_SE) );
-		C_1 = - ( C_2*dot_l_MTC + D_0 + F_SEE - F_PEE + (MP_CE_F_max*A_rel) );
-		C_0 = D_0*dot_l_MTC + MP_CE_l_CEopt * B_rel * ( F_SEE - F_PEE - MP_CE_F_max*a*F_isom );
-		dot_l_CE = (-C_1+sqrt(C_1*C_1-4*C_2*C_0))/(2*C_2); //quadratic equation for eccentric contractions (+sqrt)
-		//printf("hillMuscle-dot_l_CE: %f (recalculated)\n", dot_l_CE);
-	}
+    if (dot_l_CE >
+        0)  // dot_l_CE > 0 -> eccentric contraction -> recalculate dot_l_CE
+    {
+        double A_rel_con = A_rel;
+        double B_rel_con = B_rel;
+        A_rel = -MP_CE_F_eccentric * a * F_isom;
+        B_rel = a * F_isom * (1 - MP_CE_F_eccentric) /
+                (a * F_isom + A_rel_con) * B_rel_con / MP_CE_S_eccentric;
+        D_0 = MP_CE_l_CEopt * B_rel * MP_SDE_d_SEmax *
+              (MP_SDE_R_SE +
+               (1 - MP_SDE_R_SE) * (a * F_isom + F_PEE / MP_CE_F_max));
+        C_2 = MP_SDE_d_SEmax *
+              (MP_SDE_R_SE - (A_rel - F_PEE / MP_CE_F_max) * (1 - MP_SDE_R_SE));
+        C_1 = -(C_2 * dot_l_MTC + D_0 + F_SEE - F_PEE + (MP_CE_F_max * A_rel));
+        C_0 = D_0 * dot_l_MTC + MP_CE_l_CEopt * B_rel *
+                                    (F_SEE - F_PEE - MP_CE_F_max * a * F_isom);
+        dot_l_CE =
+            (-C_1 + sqrt(C_1 * C_1 - 4 * C_2 * C_0)) /
+            (2 * C_2);  // quadratic equation for eccentric contractions (+sqrt)
+        // printf("hillMuscle-dot_l_CE: %f (recalculated)\n", dot_l_CE);
+    }
 
-	dot_l_CE_current = dot_l_CE;
+    dot_l_CE_current = dot_l_CE;
 
-	double F_CE = MP_CE_F_max * (  ( (a*F_isom+A_rel) / ( 1- (dot_l_CE/(B_rel*MP_CE_l_CEopt)) ) )-A_rel );
+    double F_CE =
+        MP_CE_F_max *
+        (((a * F_isom + A_rel) / (1 - (dot_l_CE / (B_rel * MP_CE_l_CEopt)))) -
+         A_rel);
 
-	double F_SDE = MP_SDE_d_SEmax*((1-MP_SDE_R_SE)*((F_CE+F_PEE)/MP_CE_F_max)+MP_SDE_R_SE)*(dot_l_MTC-dot_l_CE);
+    double F_SDE =
+        MP_SDE_d_SEmax *
+        ((1 - MP_SDE_R_SE) * ((F_CE + F_PEE) / MP_CE_F_max) + MP_SDE_R_SE) *
+        (dot_l_MTC - dot_l_CE);
 
-	F_MTU_current = F_SEE + F_SDE;
-
+    F_MTU_current = F_SEE + F_SDE;
 }
 
 double HillMuscle::find_l_CE_init()
 {
-    std::function<double (double)> f(std::bind(&HillMuscle::F_sum_init_muscle_force_equilib, this, std::placeholders::_1));
+    std::function<double(double)> f(
+        std::bind(&HillMuscle::F_sum_init_muscle_force_equilib,
+                  this,
+                  std::placeholders::_1));
     return brents_fun(f, 0, MP_l_MTC_init, 0.00000001, 1000);
 }
-
 
 double HillMuscle::F_sum_init_muscle_force_equilib(double l_CE)
 {
@@ -237,136 +326,150 @@ double HillMuscle::F_sum_init_muscle_force_equilib(double l_CE)
     double F_isom, F_PEE, F_SEE;
 
     // Isometric force (Force length relation)
-    //Guenther et al. 2007
-    if(l_CE >= MP_CE_l_CEopt) //descending branch
-        F_isom = exp( - pow( abs( ((l_CE/MP_CE_l_CEopt)-1)/MP_CE_DeltaW_limb_des ) , MP_CE_v_CElimb_des) );
-    else //ascending branch
-        F_isom = exp( - pow( abs( ((l_CE/MP_CE_l_CEopt)-1)/MP_CE_DeltaW_limb_asc ) , MP_CE_v_CElimb_asc ) );
+    // Guenther et al. 2007
+    if (l_CE >= MP_CE_l_CEopt)  // descending branch
+        F_isom =
+            exp(-pow(abs(((l_CE / MP_CE_l_CEopt) - 1) / MP_CE_DeltaW_limb_des),
+                     MP_CE_v_CElimb_des));
+    else  // ascending branch
+        F_isom =
+            exp(-pow(abs(((l_CE / MP_CE_l_CEopt) - 1) / MP_CE_DeltaW_limb_asc),
+                     MP_CE_v_CElimb_asc));
 
     // Force of the parallel elastic element
-    if(l_CE >= MP_PEE_l_PEE0)
-        F_PEE = MP_PEE_K_PEE * pow(l_CE-MP_PEE_l_PEE0, MP_PEE_v_PEE);
-    else // shorter than slack length
+    if (l_CE >= MP_PEE_l_PEE0)
+        F_PEE = MP_PEE_K_PEE * pow(l_CE - MP_PEE_l_PEE0, MP_PEE_v_PEE);
+    else  // shorter than slack length
         F_PEE = 0;
 
-
     // Force of the serial elastic element
-    double l_SEE = abs(l_MTC-l_CE);
-    if ((l_SEE>MP_SEE_l_SEE0) && (l_SEE<MP_SEE_l_SEEnll)) //non-linear part
-        F_SEE = MP_SEE_KSEEnl* pow(l_SEE-MP_SEE_l_SEE0, MP_SEE_v_SEE);
-    else if(l_SEE>=MP_SEE_l_SEEnll) //linear part
-        F_SEE = MP_SEE_DeltaF_SEE0+MP_SEE_KSEEl*(l_SEE-MP_SEE_l_SEEnll);
-    else //salck length
+    double l_SEE = abs(l_MTC - l_CE);
+    if ((l_SEE > MP_SEE_l_SEE0) && (l_SEE < MP_SEE_l_SEEnll))  // non-linear
+                                                               // part
+        F_SEE = MP_SEE_KSEEnl * pow(l_SEE - MP_SEE_l_SEE0, MP_SEE_v_SEE);
+    else if (l_SEE >= MP_SEE_l_SEEnll)  // linear part
+        F_SEE = MP_SEE_DeltaF_SEE0 + MP_SEE_KSEEl * (l_SEE - MP_SEE_l_SEEnll);
+    else  // salck length
         F_SEE = 0;
 
     // Contractile element force (isometric)
-    double F_CE = MP_CE_F_max*a_init*F_isom;
+    double F_CE = MP_CE_F_max * a_init * F_isom;
 
-    double F_sum = F_SEE-F_CE-F_PEE;
+    double F_sum = F_SEE - F_CE - F_PEE;
 
     return F_sum;
 }
 
-
-
-//source: RosettaCode  https://rosettacode.org/wiki/Roots_of_a_function
-double HillMuscle::brents_fun(std::function<double (double)> f, double lower, double upper, double tol, unsigned int max_iter)
+// source: RosettaCode  https://rosettacode.org/wiki/Roots_of_a_function
+double HillMuscle::brents_fun(std::function<double(double)> f,
+                              double lower,
+                              double upper,
+                              double tol,
+                              unsigned int max_iter)
 {
-	double a = lower;
-	double b = upper;
-	double fa = f(a);	// calculated now to save function calls
-	double fb = f(b);	// calculated now to save function calls
-	double fs = 0;		// initialize
+    double a = lower;
+    double b = upper;
+    double fa = f(a);  // calculated now to save function calls
+    double fb = f(b);  // calculated now to save function calls
+    double fs = 0;     // initialize
 
-	if (!(fa * fb < 0))
-	{
+    if (!(fa * fb < 0))
+    {
+        if (fb == 0) return b;
+        if (fa == 0) return a;
+        // std::cout << "Signs of f(lower_bound):" << fa <<" and
+        // f(upper_bound):" << fb <<" must be opposites" << std::endl; // throws
+        // exception if root isn't bracketed
+        return -11;
+    }
 
-		if(fb==0)
-			return b;
-		if(fa==0)
-			return a;
-		//std::cout << "Signs of f(lower_bound):" << fa <<" and f(upper_bound):" << fb <<" must be opposites" << std::endl; // throws exception if root isn't bracketed
-		return -11;
-	}
+    if (std::abs(fa) < std::abs(b))  // if magnitude of f(lower_bound) is less
+                                     // than magnitude of f(upper_bound)
+    {
+        std::swap(a, b);
+        std::swap(fa, fb);
+    }
 
-	if (std::abs(fa) < std::abs(b))	// if magnitude of f(lower_bound) is less than magnitude of f(upper_bound)
-	{
-		std::swap(a,b);
-		std::swap(fa,fb);
-	}
+    double c =
+        a;  // c now equals the largest magnitude of the lower and upper bounds
+    double fc = fa;  // precompute function evalutation for point c by assigning
+                     // it the same value as fa
+    bool mflag = true;  // boolean flag used to evaluate if statement later on
+    double s = 0;       // Our Root that will be returned
+    double d = 0;       // Only used if mflag is unset (mflag == false)
 
-	double c = a;			// c now equals the largest magnitude of the lower and upper bounds
-	double fc = fa;			// precompute function evalutation for point c by assigning it the same value as fa
-	bool mflag = true;		// boolean flag used to evaluate if statement later on
-	double s = 0;			// Our Root that will be returned
-	double d = 0;			// Only used if mflag is unset (mflag == false)
+    for (unsigned int iter = 1; iter < max_iter; ++iter)
+    {
+        // stop if converged on root or error is less than tolerance
+        if (std::abs(b - a) < tol)
+        {
+            return s;
+        }  // end if
 
-	for (unsigned int iter = 1; iter < max_iter; ++iter)
-	{
-		// stop if converged on root or error is less than tolerance
-		if (std::abs(b-a) < tol)
-		{
-			return s;
-		} // end if
+        if (fa != fc && fb != fc)
+        {
+            // use inverse quadratic interopolation
+            s = (a * fb * fc / ((fa - fb) * (fa - fc))) +
+                (b * fa * fc / ((fb - fa) * (fb - fc))) +
+                (c * fa * fb / ((fc - fa) * (fc - fb)));
+        }
+        else
+        {
+            // secant method
+            s = b - fb * (b - a) / (fb - fa);
+        }
 
-		if (fa != fc && fb != fc)
-		{
-			// use inverse quadratic interopolation
-			s =	  ( a * fb * fc / ((fa - fb) * (fa - fc)) )
-				+ ( b * fa * fc / ((fb - fa) * (fb - fc)) )
-				+ ( c * fa * fb / ((fc - fa) * (fc - fb)) );
-		}
-		else
-		{
-			// secant method
-			s = b - fb * (b - a) / (fb - fa);
-		}
+        // checks to see whether we can use the faster converging quadratic &&
+        // secant methods or if we need to use bisection
+        if (((s < (3 * a + b) * 0.25) || (s > b)) ||
+            (mflag && (std::abs(s - b) >= (std::abs(b - c) * 0.5))) ||
+            (!mflag && (std::abs(s - b) >= (std::abs(c - d) * 0.5))) ||
+            (mflag && (std::abs(b - c) < tol)) ||
+            (!mflag && (std::abs(c - d) < tol)))
+        {
+            // bisection method
+            s = (a + b) * 0.5;
 
-			// checks to see whether we can use the faster converging quadratic && secant methods or if we need to use bisection
-		if (	( (s < (3 * a + b) * 0.25) || (s > b) ) ||
-				( mflag && (std::abs(s-b) >= (std::abs(b-c) * 0.5)) ) ||
-				( !mflag && (std::abs(s-b) >= (std::abs(c-d) * 0.5)) ) ||
-				( mflag && (std::abs(b-c) < tol) ) ||
-				( !mflag && (std::abs(c-d) < tol))	)
-		{
-			// bisection method
-			s = (a+b)*0.5;
+            mflag = true;
+        }
+        else
+        {
+            mflag = false;
+        }
 
-			mflag = true;
-		}
-		else
-		{
-			mflag = false;
-		}
+        fs = f(s);  // calculate fs
+        d = c;      // first time d is being used (wasnt used on first iteration
+                    // because mflag was set)
+        c = b;      // set c equal to upper bound
+        fc = fb;    // set f(c) = f(b)
 
-		fs = f(s);	// calculate fs
-		d = c;		// first time d is being used (wasnt used on first iteration because mflag was set)
-		c = b;		// set c equal to upper bound
-		fc = fb;	// set f(c) = f(b)
+        if (fa * fs < 0)  // fa and fs have opposite signs
+        {
+            b = s;
+            fb = fs;  // set f(b) = f(s)
+        }
+        else
+        {
+            a = s;
+            fa = fs;  // set f(a) = f(s)
+        }
 
-		if ( fa * fs < 0)	// fa and fs have opposite signs
-		{
-			b = s;
-			fb = fs;	// set f(b) = f(s)
-		}
-		else
-		{
-			a = s;
-			fa = fs;	// set f(a) = f(s)
-		}
+        if (std::abs(fa) <
+            std::abs(fb))  // if magnitude of fa is less than magnitude of fb
+        {
+            std::swap(a, b);  // swap a and b
+            std::swap(fa,
+                      fb);  // make sure f(a) and f(b) are correct after swap
+        }
 
-		if (std::abs(fa) < std::abs(fb)) // if magnitude of fa is less than magnitude of fb
-		{
-			std::swap(a,b);		// swap a and b
-			std::swap(fa,fb);	// make sure f(a) and f(b) are correct after swap
-		}
+    }  // end for
 
-	} // end for
+    // std::cout<< "The solution does not converge or iterations are not
+    // sufficient" << std::endl;
 
-	//std::cout<< "The solution does not converge or iterations are not sufficient" << std::endl;
-
-	return -1;
-
+    return -1;
 }
 
-}}}
+}  // namespace deprecated
+}  // namespace hill
+}  // namespace pam_models

--- a/src/hill/internal/deprecated/deprecated_muscle.cpp
+++ b/src/hill/internal/deprecated/deprecated_muscle.cpp
@@ -42,6 +42,9 @@ Copyright notice from the MATLAB model by Haeufle et al.:
 
 **/
 
+// clang-format off
+// TODO: there is some issue here that makes the build break if the order of
+// includes is wrong.
 #include "stdio.h"
 #include "math.h"
 #include <cmath>
@@ -50,6 +53,7 @@ Copyright notice from the MATLAB model by Haeufle et al.:
 #include <iostream>
 #include "json_helper/json_helper.hpp"
 #include "pam_models/hill/deprecated/deprecated_muscle.hpp"
+// clang-format on
 
 namespace pam_models
 {

--- a/src/hill/internal/parallel_elastic_element.cpp
+++ b/src/hill/internal/parallel_elastic_element.cpp
@@ -3,34 +3,36 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    ParallelElasticElement::ParallelElasticElement(const ContractileElement& contractile_element,
-			     double MP_PEE_L_PEE0,
-			     double MP_PEE_v_PEE,
-			     double MP_PEE_F_PEE )
-	: MP_PEE_L_PEE0_(MP_PEE_L_PEE0),
-	  MP_PEE_v_PEE_(MP_PEE_v_PEE),
-	  MP_PEE_F_PEE_(MP_PEE_F_PEE),
-	  MP_PEE_l_PEE0_(MP_PEE_L_PEE0* contractile_element.MP_CE_l_CEopt_),
-	  MP_PEE_K_PEE_ ( MP_PEE_F_PEE_ *
-			 ( contractile_element.MP_CE_F_max_ /
-			   pow( contractile_element.MP_CE_l_CEopt_ *
-				( contractile_element.MP_CE_DeltaW_limb_des_+1-MP_PEE_L_PEE0),
-				MP_PEE_v_PEE )) )
-      {}
-
-    double ParallelElasticElement::get_force(double l_CE)
-      {
-	if(l_CE>=MP_PEE_l_PEE0_)
-	  {
-	    return MP_PEE_K_PEE_*pow(l_CE-MP_PEE_l_PEE0_, MP_PEE_v_PEE_);
-	  }
-	return 0;
-      }
-      
-
-  }
-
+ParallelElasticElement::ParallelElasticElement(
+    const ContractileElement& contractile_element,
+    double MP_PEE_L_PEE0,
+    double MP_PEE_v_PEE,
+    double MP_PEE_F_PEE)
+    : MP_PEE_L_PEE0_(MP_PEE_L_PEE0),
+      MP_PEE_v_PEE_(MP_PEE_v_PEE),
+      MP_PEE_F_PEE_(MP_PEE_F_PEE),
+      MP_PEE_l_PEE0_(MP_PEE_L_PEE0 * contractile_element.MP_CE_l_CEopt_),
+      MP_PEE_K_PEE_(MP_PEE_F_PEE_ *
+                    (contractile_element.MP_CE_F_max_ /
+                     pow(contractile_element.MP_CE_l_CEopt_ *
+                             (contractile_element.MP_CE_DeltaW_limb_des_ + 1 -
+                              MP_PEE_L_PEE0),
+                         MP_PEE_v_PEE)))
+{
 }
+
+double ParallelElasticElement::get_force(double l_CE)
+{
+    if (l_CE >= MP_PEE_l_PEE0_)
+    {
+        return MP_PEE_K_PEE_ * pow(l_CE - MP_PEE_l_PEE0_, MP_PEE_v_PEE_);
+    }
+    return 0;
+}
+
+}  // namespace hill
+
+}  // namespace pam_models

--- a/src/hill/internal/serial_damping_element.cpp
+++ b/src/hill/internal/serial_damping_element.cpp
@@ -3,31 +3,34 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    SerialDampingElement::SerialDampingElement(const ContractileElement& contractile_element,
-					       double MP_SDE_D_SE,
-					       double MP_SDE_R_SE)
-      : MP_SDE_D_SE_(MP_SDE_D_SE),
-	MP_SDE_R_SE_(MP_SDE_R_SE),
-	MP_SDE_d_SEmax_( MP_SDE_D_SE *
-			 ( contractile_element.MP_CE_F_max_* contractile_element.MP_CE_A_rel0_ )
-			 / ( contractile_element.MP_CE_l_CEopt_ *
-			     contractile_element.MP_CE_B_rel0_) )
-    {}
-
-    // line 205
-    double SerialDampingElement::get_force(double F_CE,
-					   double F_PEE,
-					   double MP_CE_F_max,
-					   double dot_l_MTC,
-					   double dot_l_CE)
-    {
-      double t1 = (1-MP_SDE_R_SE_)*((F_CE+F_PEE)/MP_CE_F_max);
-      double t2 = dot_l_MTC-dot_l_CE;
-      return MP_SDE_d_SEmax_*(t1+MP_SDE_R_SE_)*(t2);
-    }
-
-  }
+SerialDampingElement::SerialDampingElement(
+    const ContractileElement& contractile_element,
+    double MP_SDE_D_SE,
+    double MP_SDE_R_SE)
+    : MP_SDE_D_SE_(MP_SDE_D_SE),
+      MP_SDE_R_SE_(MP_SDE_R_SE),
+      MP_SDE_d_SEmax_(MP_SDE_D_SE *
+                      (contractile_element.MP_CE_F_max_ *
+                       contractile_element.MP_CE_A_rel0_) /
+                      (contractile_element.MP_CE_l_CEopt_ *
+                       contractile_element.MP_CE_B_rel0_))
+{
 }
+
+// line 205
+double SerialDampingElement::get_force(double F_CE,
+                                       double F_PEE,
+                                       double MP_CE_F_max,
+                                       double dot_l_MTC,
+                                       double dot_l_CE)
+{
+    double t1 = (1 - MP_SDE_R_SE_) * ((F_CE + F_PEE) / MP_CE_F_max);
+    double t2 = dot_l_MTC - dot_l_CE;
+    return MP_SDE_d_SEmax_ * (t1 + MP_SDE_R_SE_) * (t2);
+}
+
+}  // namespace hill
+}  // namespace pam_models

--- a/src/hill/internal/serial_elastic_element.cpp
+++ b/src/hill/internal/serial_elastic_element.cpp
@@ -3,56 +3,55 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
-    SerialElasticElement::SerialElasticElement(double l_0, double deltaU_nll,
-					       double deltaU_l, double deltaF_0)
-      : l_0_(l_0),
-	deltaU_nll_(deltaU_nll),
-	deltaU_l_(deltaU_l),
-	deltaF_0_(deltaF_0),
-	l_nll_( (1 + deltaU_nll)* l_0 ),
-	v_( deltaU_nll/ deltaU_l ),
-	k_nl_( deltaF_0
-	       / pow( deltaU_nll* l_0,  v_) ),
-	k_l_( deltaF_0 / ( deltaU_l* l_0) )
-    {}
-	
+SerialElasticElement::SerialElasticElement(double l_0,
+                                           double deltaU_nll,
+                                           double deltaU_l,
+                                           double deltaF_0)
+    : l_0_(l_0),
+      deltaU_nll_(deltaU_nll),
+      deltaU_l_(deltaU_l),
+      deltaF_0_(deltaF_0),
+      l_nll_((1 + deltaU_nll) * l_0),
+      v_(deltaU_nll / deltaU_l),
+      k_nl_(deltaF_0 / pow(deltaU_nll * l_0, v_)),
+      k_l_(deltaF_0 / (deltaU_l * l_0))
+{
+}
 
-    double SerialElasticElement::init_serial_elastic_element_force(double l_mtc,
-								   double l_ce)
+double SerialElasticElement::init_serial_elastic_element_force(double l_mtc,
+                                                               double l_ce)
+{
+    double f;
+    double l = fabs(l_mtc - l_ce);
+    // non-linear part
+    if ((l > l_0_) && (l < l_nll_))
     {
-      double f;
-      double l = fabs(l_mtc-l_ce);
-      //non-linear part
-      if ((l>l_0_) && (l<l_nll_))
-	{
-	  f = k_nl_* pow(l-l_0_, v_);
-	}
-      //linear part
-      else if(l>=l_nll_)
-	{
-	  f = deltaF_0_+k_l_*(l-l_nll_);
-	}
-      //slack length
-      else
-	{
-	  f = 0;
-	}
-      return f;
-  }
-
-  double SerialElasticElement::get_force(double l_MTC,double l_CE)
-  {
-    double l_se = l_MTC-l_CE;
-    double f = (l_se>=l_nll_) * (deltaF_0_+k_l_*(l_se-l_nll_));
-    if (l_se>l_0_ && l_se<l_nll_)
-      f+=k_nl_*(pow(l_se-l_0_, v_));
+        f = k_nl_ * pow(l - l_0_, v_);
+    }
+    // linear part
+    else if (l >= l_nll_)
+    {
+        f = deltaF_0_ + k_l_ * (l - l_nll_);
+    }
+    // slack length
+    else
+    {
+        f = 0;
+    }
     return f;
-  }
-	
-}
-  
 }
 
+double SerialElasticElement::get_force(double l_MTC, double l_CE)
+{
+    double l_se = l_MTC - l_CE;
+    double f = (l_se >= l_nll_) * (deltaF_0_ + k_l_ * (l_se - l_nll_));
+    if (l_se > l_0_ && l_se < l_nll_) f += k_nl_ * (pow(l_se - l_0_, v_));
+    return f;
+}
+
+}  // namespace hill
+
+}  // namespace pam_models

--- a/src/hill/muscle.cpp
+++ b/src/hill/muscle.cpp
@@ -3,198 +3,194 @@
 namespace pam_models
 {
 
-  namespace hill
-  {
+namespace hill
+{
 
+// line 218
+double init_muscle_force_equilibrium(double l_CE,
+                                     const ParallelElasticElement& PEE,
+                                     const ContractileElement& CE,
+                                     const SerialElasticElement& SEE,
+                                     double a_init,
+                                     double MP_l_MTC_init)
 
-    // line 218
-    double init_muscle_force_equilibrium(double l_CE,
-					 const ParallelElasticElement& PEE,
-					 const ContractileElement& CE,
-					 const SerialElasticElement& SEE,
-					 double a_init,
-					 double MP_l_MTC_init)
-					 
+{
+    double l_MTC = MP_l_MTC_init;
+
+    // Isometric force (Force length relation)
+    // Guenther et al. 2007
+    double F_isom;
+    if (l_CE >= CE.MP_CE_l_CEopt_)  // descending branch
     {
-      double l_MTC = MP_l_MTC_init;
-
-      // Isometric force (Force length relation)
-      //Guenther et al. 2007
-      double F_isom;
-      if(l_CE >= CE.MP_CE_l_CEopt_) //descending branch
-	{
-	  F_isom =
-	    exp( - pow( abs( ((l_CE/CE.MP_CE_l_CEopt_)-1)/CE.MP_CE_DeltaW_limb_des_ ) ,
-			CE.MP_CE_v_CElimb_des_) );
-	}
-      else //ascending branch
-	{
-        F_isom =
-	  exp( - pow( abs( ((l_CE/CE.MP_CE_l_CEopt_)-1)/CE.MP_CE_DeltaW_limb_asc_ ) ,
-		      CE.MP_CE_v_CElimb_asc_ ) );
-	}
-      
-      // Force of the parallel elastic element
-      double F_PEE;
-      if(l_CE >= PEE.MP_PEE_l_PEE0_)
-	{
-	  F_PEE = PEE.MP_PEE_K_PEE_ * pow(l_CE-PEE.MP_PEE_l_PEE0_, PEE.MP_PEE_v_PEE_);
-	}
-      else // shorter than slack length
-	{
-	  F_PEE = 0;
-	}
-
-      // Force of the serial elastic element
-      double F_SEE;
-      double l_SEE = abs(l_MTC-l_CE);
-      if ((l_SEE>SEE.l_0_) && (l_SEE<SEE.l_nll_)) //non-linear part
-	{
-	  F_SEE = SEE.k_nl_* pow(l_SEE-SEE.l_0_, SEE.v_);
-	}
-      else if(l_SEE>=SEE.l_nll_) //linear part
-	{
-	  F_SEE = SEE.deltaF_0_+SEE.k_l_*(l_SEE-SEE.l_nll_);
-	}
-      else //slack length
-	{
-	  F_SEE = 0;
-	}
-
-      // Contractile element force (isometric)
-      double F_CE = CE.MP_CE_F_max_*a_init*F_isom;
-
-      double F_sum = F_SEE-F_CE-F_PEE;
-
-      return F_sum;
+        F_isom = exp(-pow(
+            abs(((l_CE / CE.MP_CE_l_CEopt_) - 1) / CE.MP_CE_DeltaW_limb_des_),
+            CE.MP_CE_v_CElimb_des_));
+    }
+    else  // ascending branch
+    {
+        F_isom = exp(-pow(
+            abs(((l_CE / CE.MP_CE_l_CEopt_) - 1) / CE.MP_CE_DeltaW_limb_asc_),
+            CE.MP_CE_v_CElimb_asc_));
     }
 
+    // Force of the parallel elastic element
+    double F_PEE;
+    if (l_CE >= PEE.MP_PEE_l_PEE0_)
+    {
+        F_PEE = PEE.MP_PEE_K_PEE_ *
+                pow(l_CE - PEE.MP_PEE_l_PEE0_, PEE.MP_PEE_v_PEE_);
+    }
+    else  // shorter than slack length
+    {
+        F_PEE = 0;
+    }
 
-    
-    Muscle::Muscle(ContractileElement contractile,
-		   ParallelElasticElement parallel_elastic,
-		   SerialDampingElement serial_damping,
-		   SerialElasticElement serial_elastic,
-		   double a_init,
-		   double l_MTC_change_init,
-		   double length)
-      : contractile_(contractile),
-	parallel_elastic_(parallel_elastic),
-	serial_damping_(serial_damping),
-	serial_elastic_(serial_elastic),
-	MP_l_MTC_init_(length+l_MTC_change_init),
-	a_init_(a_init)
-      {
-	std::function<double(double)> f(std::bind(init_muscle_force_equilibrium,
-						  std::placeholders::_1,
-						  parallel_elastic_,
-						  contractile_,
-						  serial_elastic_,
-						  a_init,
-						  MP_l_MTC_init_));
-	MP_l_CE_init_ = brents(f, 0, MP_l_MTC_init_);
-      }
+    // Force of the serial elastic element
+    double F_SEE;
+    double l_SEE = abs(l_MTC - l_CE);
+    if ((l_SEE > SEE.l_0_) && (l_SEE < SEE.l_nll_))  // non-linear part
+    {
+        F_SEE = SEE.k_nl_ * pow(l_SEE - SEE.l_0_, SEE.v_);
+    }
+    else if (l_SEE >= SEE.l_nll_)  // linear part
+    {
+        F_SEE = SEE.deltaF_0_ + SEE.k_l_ * (l_SEE - SEE.l_nll_);
+    }
+    else  // slack length
+    {
+        F_SEE = 0;
+    }
 
+    // Contractile element force (isometric)
+    double F_CE = CE.MP_CE_F_max_ * a_init * F_isom;
 
-      // line 142, returns F_MTU_current and dot_l_CE_current
-      std::tuple<double,double> Muscle::get(double l_MTC, double dot_l_MTC, double a, double l_CE)
-      {
-	
-	l_MTC = l_MTC + MP_l_MTC_init_;
-	l_CE = l_CE + MP_l_CE_init_;
+    double F_sum = F_SEE - F_CE - F_PEE;
 
-	double F_isom = contractile_.get_isometric_force(l_CE);
-	double F_PEE = parallel_elastic_.get_force(l_CE);
-	double F_SEE = serial_elastic_.get_force(l_MTC,l_CE);
-	double A_rel = contractile_.get_a_relative(l_CE,F_isom,a);
-	double B_rel = contractile_.get_b_relative(a);
-
-	double D_0;
-	{
-	  D_0 = contractile_.MP_CE_l_CEopt_ * B_rel * serial_damping_.MP_SDE_d_SEmax_;
-	  D_0 *= ( serial_damping_.MP_SDE_R_SE_ + (1-serial_damping_.MP_SDE_R_SE_) *
-		   ( a * F_isom + F_PEE/contractile_.MP_CE_F_max_ ) );
-	}
-
-	double C_2;
-	{
-	  double rel = A_rel - F_PEE / contractile_.MP_CE_F_max_;
-	  double one_min = 1.0 - serial_damping_.MP_SDE_R_SE_;
-	  C_2= serial_damping_.MP_SDE_d_SEmax_ * ( serial_damping_.MP_SDE_R_SE_ - rel  * one_min );
-	}
-
-	double C_1;
-	{
-	  C_1 = - ( C_2*dot_l_MTC + D_0 + F_SEE - F_PEE + (contractile_.MP_CE_F_max_*A_rel) );
-	}
-	
-	double C_0;
-	{
-	  double f_s = F_SEE - F_PEE - contractile_.MP_CE_F_max_*a*F_isom;
-	  C_0= D_0*dot_l_MTC +
-	    contractile_.MP_CE_l_CEopt_ * B_rel * f_s;
-	}
-	
-	//quadratic equation for concentric contractions (-sqrt)
-	double dot_l_CE = (-C_1-sqrt(C_1*C_1-4*C_2*C_0))/(2*C_2);
-
-	if(dot_l_CE>0)  //dot_l_CE > 0 -> eccentric contraction -> recalculate dot_l_CE
-	  {
-	    double A_rel_con = A_rel;
-	    double B_rel_con = B_rel;
-	    A_rel = -contractile_.MP_CE_F_eccentric_*a*F_isom;
-	    B_rel =
-	      a*F_isom*(1-contractile_.MP_CE_F_eccentric_) /
-	      (a*F_isom+A_rel_con)*B_rel_con/contractile_.MP_CE_S_eccentric_;
-	    D_0 =
-	      contractile_.MP_CE_l_CEopt_ * B_rel * serial_damping_.MP_SDE_d_SEmax_ *
-	      ( serial_damping_.MP_SDE_R_SE_ +
-		(1-serial_damping_.MP_SDE_R_SE_) *
-		( a * F_isom + F_PEE/
-		  contractile_.MP_CE_F_max_ ) );
-	    C_2 =
-	      serial_damping_.MP_SDE_d_SEmax_ *
-	      ( serial_damping_.MP_SDE_R_SE_ -
-		( A_rel - F_PEE/contractile_.MP_CE_F_max_ ) * (1 - serial_damping_.MP_SDE_R_SE_) );
-	    C_1 =
-	      - ( C_2*dot_l_MTC + D_0 + F_SEE - F_PEE + (contractile_.MP_CE_F_max_*A_rel) );
-	    C_0 =
-	      D_0*dot_l_MTC + contractile_.MP_CE_l_CEopt_ * B_rel *
-	      ( F_SEE - F_PEE - contractile_.MP_CE_F_max_*a*F_isom );
-	    //quadratic equation for eccentric contractions (+sqrt)
-	    dot_l_CE = (-C_1+sqrt(C_1*C_1-4*C_2*C_0))/(2*C_2);
-	  }
-
-	double dot_l_CE_current = dot_l_CE;
-
-	double F_CE;
-	{
-	  F_CE = contractile_.MP_CE_F_max_;
-	  F_CE *=
-	    ( (a*F_isom+A_rel) /
-	      ( 1- (dot_l_CE/(B_rel*contractile_.MP_CE_l_CEopt_)) ) )
-	    - A_rel ;
-	}
-	
-	double F_SDE;
-	{
-	  F_SDE = serial_damping_.MP_SDE_d_SEmax_ *
-	    ( (1-serial_damping_.MP_SDE_R_SE_) *
-	      ((F_CE+F_PEE)/contractile_.MP_CE_F_max_)+serial_damping_.MP_SDE_R_SE_) *
-	    (dot_l_MTC-dot_l_CE);
-	}
-	  
-	double F_MTU_current = F_SEE + F_SDE;
-
-	return std::make_tuple(F_MTU_current,dot_l_CE_current);
-	
-      }
-      
-      
-
-  }
-  
+    return F_sum;
 }
 
+Muscle::Muscle(ContractileElement contractile,
+               ParallelElasticElement parallel_elastic,
+               SerialDampingElement serial_damping,
+               SerialElasticElement serial_elastic,
+               double a_init,
+               double l_MTC_change_init,
+               double length)
+    : contractile_(contractile),
+      parallel_elastic_(parallel_elastic),
+      serial_damping_(serial_damping),
+      serial_elastic_(serial_elastic),
+      MP_l_MTC_init_(length + l_MTC_change_init),
+      a_init_(a_init)
+{
+    std::function<double(double)> f(std::bind(init_muscle_force_equilibrium,
+                                              std::placeholders::_1,
+                                              parallel_elastic_,
+                                              contractile_,
+                                              serial_elastic_,
+                                              a_init,
+                                              MP_l_MTC_init_));
+    MP_l_CE_init_ = brents(f, 0, MP_l_MTC_init_);
+}
 
+// line 142, returns F_MTU_current and dot_l_CE_current
+std::tuple<double, double> Muscle::get(double l_MTC,
+                                       double dot_l_MTC,
+                                       double a,
+                                       double l_CE)
+{
+    l_MTC = l_MTC + MP_l_MTC_init_;
+    l_CE = l_CE + MP_l_CE_init_;
 
+    double F_isom = contractile_.get_isometric_force(l_CE);
+    double F_PEE = parallel_elastic_.get_force(l_CE);
+    double F_SEE = serial_elastic_.get_force(l_MTC, l_CE);
+    double A_rel = contractile_.get_a_relative(l_CE, F_isom, a);
+    double B_rel = contractile_.get_b_relative(a);
+
+    double D_0;
+    {
+        D_0 = contractile_.MP_CE_l_CEopt_ * B_rel *
+              serial_damping_.MP_SDE_d_SEmax_;
+        D_0 *= (serial_damping_.MP_SDE_R_SE_ +
+                (1 - serial_damping_.MP_SDE_R_SE_) *
+                    (a * F_isom + F_PEE / contractile_.MP_CE_F_max_));
+    }
+
+    double C_2;
+    {
+        double rel = A_rel - F_PEE / contractile_.MP_CE_F_max_;
+        double one_min = 1.0 - serial_damping_.MP_SDE_R_SE_;
+        C_2 = serial_damping_.MP_SDE_d_SEmax_ *
+              (serial_damping_.MP_SDE_R_SE_ - rel * one_min);
+    }
+
+    double C_1;
+    {
+        C_1 = -(C_2 * dot_l_MTC + D_0 + F_SEE - F_PEE +
+                (contractile_.MP_CE_F_max_ * A_rel));
+    }
+
+    double C_0;
+    {
+        double f_s = F_SEE - F_PEE - contractile_.MP_CE_F_max_ * a * F_isom;
+        C_0 = D_0 * dot_l_MTC + contractile_.MP_CE_l_CEopt_ * B_rel * f_s;
+    }
+
+    // quadratic equation for concentric contractions (-sqrt)
+    double dot_l_CE = (-C_1 - sqrt(C_1 * C_1 - 4 * C_2 * C_0)) / (2 * C_2);
+
+    if (dot_l_CE >
+        0)  // dot_l_CE > 0 -> eccentric contraction -> recalculate dot_l_CE
+    {
+        double A_rel_con = A_rel;
+        double B_rel_con = B_rel;
+        A_rel = -contractile_.MP_CE_F_eccentric_ * a * F_isom;
+        B_rel = a * F_isom * (1 - contractile_.MP_CE_F_eccentric_) /
+                (a * F_isom + A_rel_con) * B_rel_con /
+                contractile_.MP_CE_S_eccentric_;
+        D_0 = contractile_.MP_CE_l_CEopt_ * B_rel *
+              serial_damping_.MP_SDE_d_SEmax_ *
+              (serial_damping_.MP_SDE_R_SE_ +
+               (1 - serial_damping_.MP_SDE_R_SE_) *
+                   (a * F_isom + F_PEE / contractile_.MP_CE_F_max_));
+        C_2 = serial_damping_.MP_SDE_d_SEmax_ *
+              (serial_damping_.MP_SDE_R_SE_ -
+               (A_rel - F_PEE / contractile_.MP_CE_F_max_) *
+                   (1 - serial_damping_.MP_SDE_R_SE_));
+        C_1 = -(C_2 * dot_l_MTC + D_0 + F_SEE - F_PEE +
+                (contractile_.MP_CE_F_max_ * A_rel));
+        C_0 = D_0 * dot_l_MTC +
+              contractile_.MP_CE_l_CEopt_ * B_rel *
+                  (F_SEE - F_PEE - contractile_.MP_CE_F_max_ * a * F_isom);
+        // quadratic equation for eccentric contractions (+sqrt)
+        dot_l_CE = (-C_1 + sqrt(C_1 * C_1 - 4 * C_2 * C_0)) / (2 * C_2);
+    }
+
+    double dot_l_CE_current = dot_l_CE;
+
+    double F_CE;
+    {
+        F_CE = contractile_.MP_CE_F_max_;
+        F_CE *= ((a * F_isom + A_rel) /
+                 (1 - (dot_l_CE / (B_rel * contractile_.MP_CE_l_CEopt_)))) -
+                A_rel;
+    }
+
+    double F_SDE;
+    {
+        F_SDE = serial_damping_.MP_SDE_d_SEmax_ *
+                ((1 - serial_damping_.MP_SDE_R_SE_) *
+                     ((F_CE + F_PEE) / contractile_.MP_CE_F_max_) +
+                 serial_damping_.MP_SDE_R_SE_) *
+                (dot_l_MTC - dot_l_CE);
+    }
+
+    double F_MTU_current = F_SEE + F_SDE;
+
+    return std::make_tuple(F_MTU_current, dot_l_CE_current);
+}
+
+}  // namespace hill
+
+}  // namespace pam_models

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,7 +1,8 @@
 
 #include "gtest/gtest.h"
 
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1,66 +1,64 @@
-#include "gtest/gtest.h"
-#include <cstdlib>
 #include <unistd.h>
-#include <sstream>
+#include <cstdlib>
 #include <set>
+#include <sstream>
+#include "gtest/gtest.h"
 
-#include "pam_models/hill/factory.hpp"
 #include "pam_models/hill/deprecated/deprecated_muscle.hpp"
-
+#include "pam_models/hill/factory.hpp"
 
 class PamModelsHillTests : public ::testing::Test
 {
-  void SetUp(){}
-  void TearDown(){}
+    void SetUp()
+    {
+    }
+    void TearDown()
+    {
+    }
 };
 
-
-TEST_F(PamModelsHillTests,default_config_factory)
+TEST_F(PamModelsHillTests, default_config_factory)
 {
-  double a = 0.5;
-  double l_MTC = 0.05;
-  pam_models::hill::from_default_json(a,l_MTC);
+    double a = 0.5;
+    double l_MTC = 0.05;
+    pam_models::hill::from_default_json(a, l_MTC);
 }
 
-
-TEST_F(PamModelsHillTests,compare_to_known)
+TEST_F(PamModelsHillTests, compare_to_known)
 {
+    double ref_force;
+    double ref_dot_l_CE;
 
-  double ref_force;
-  double ref_dot_l_CE;
+    // deprecated implementation (considered here ground truth)
+    {
+        pam_models::hill::deprecated::HillMuscle muscle_test(
+            JSON_DEPRECATED_CONFIG_FILE, 0.5, 0.0);
+        double l_MTC = 0.05;
+        double dot_l_MTC = 0.001;
+        double a = 0.5;
+        double l_CE = 0.03;
+        ref_force =
+            muscle_test.get_mucle_tendon_force(l_MTC, dot_l_MTC, a, l_CE);
+        ref_dot_l_CE = muscle_test.get_dot_l_CE(l_MTC, dot_l_MTC, a, l_CE);
+    }
 
-  // deprecated implementation (considered here ground truth)
-  {
-    pam_models::hill::deprecated::HillMuscle muscle_test(JSON_DEPRECATED_CONFIG_FILE, 0.5, 0.0);
-    double l_MTC = 0.05;
-    double dot_l_MTC = 0.001;
-    double a = 0.5;
-    double l_CE = 0.03;
-    ref_force = muscle_test.get_mucle_tendon_force(l_MTC, dot_l_MTC, a, l_CE);
-    ref_dot_l_CE = muscle_test.get_dot_l_CE(l_MTC, dot_l_MTC, a, l_CE);
-  }
-  
-  // new implementation
-  {
-    double a_init = 0.5; 
-    double l_MTC_init = 0.0;
-    pam_models::hill::Muscle muscle = pam_models::hill::from_json(JSON_TEST_CONFIG_FILE,
-								  a_init,
-								  l_MTC_init);
+    // new implementation
+    {
+        double a_init = 0.5;
+        double l_MTC_init = 0.0;
+        pam_models::hill::Muscle muscle = pam_models::hill::from_json(
+            JSON_TEST_CONFIG_FILE, a_init, l_MTC_init);
 
-    double l_MTC = 0.05;
-    double dot_l_MTC = 0.001;
-    double a = 0.5;
-    double l_CE = 0.03;
-    std::tuple<double,double> f_dot_lce = muscle.get(l_MTC,
-						     dot_l_MTC,
-						     a,
-						     l_CE);
-    double force = std::get<0>(f_dot_lce);
-    double dot_l_CE = std::get<1>(f_dot_lce);
+        double l_MTC = 0.05;
+        double dot_l_MTC = 0.001;
+        double a = 0.5;
+        double l_CE = 0.03;
+        std::tuple<double, double> f_dot_lce =
+            muscle.get(l_MTC, dot_l_MTC, a, l_CE);
+        double force = std::get<0>(f_dot_lce);
+        double dot_l_CE = std::get<1>(f_dot_lce);
 
-    ASSERT_NEAR(force, ref_force, 0.001);
-    ASSERT_NEAR(dot_l_CE, ref_dot_l_CE, 0.001);
-  }
+        ASSERT_NEAR(force, ref_force, 0.001);
+        ASSERT_NEAR(dot_l_CE, ref_dot_l_CE, 0.001);
+    }
 }
-


### PR DESCRIPTION
## Description

Reformat C++ code with `mpi_cpp_format`.

This was initially breaking the build due to reordering of the includes in deprecated_muscle.cpp.  To prevent this, I added `// clang-format off/on` comments around the include block to disable formatting of that part (see the first of the two commits).


## How I Tested

By building the PAM_MUJOCO workspace.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
