### PR TITLE
Throw runtime_error instead of string

### DIFF
--- a/src/hill/factory.cpp
+++ b/src/hill/factory.cpp
@@ -18,8 +18,7 @@ Muscle from_json(std::string file_path, double a_init, double l_MTC_change_init)
     {
         std::stringstream ss;
         ss << "Failed to read JSON file " << file_path << "\n";
-        std::string error = ss.str();
-        throw error;
+        throw std::runtime_error(ss.str());
     }
 
     double f_max = jh.j["contractile"]["f_max"].get<double>();


### PR DESCRIPTION
## Description

This results in a more useful error message.  When just throwing the
string (without catching it), the actual message is not printed on the
terminal.

Related to https://github.com/intelligent-soft-robots/pam_interface/pull/3


## How I Tested

By adding some syntax error in the corresponding file to provoke the error.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
