### PR TITLE
Remove obsolete setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-setup_args = generate_distutils_setup(
-    packages=["pam_models"],
-    package_dir={"": "python"},
-)
-
-setup(**setup_args)


### PR DESCRIPTION
## Description

This was used by catkin and is not needed for colcon.

## How I Tested
Rebuilt workspace and manually verified that the Python packages are still importable.